### PR TITLE
Prepend ./ to single directory selections, allowing for quick cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>F</kbd> (`F` for file)
 - **Preview window:** file with syntax highlighting, directory contents, or file type
 - **Remarks**
+  - appends `./` to the selection if the selection is a single directory, allowing for quick cd into that directory (see [cd docs][])
   - ignores files that are also ignored by git
   - <kbd>Tab</kbd> to multi-select
 
@@ -171,6 +172,7 @@ Fzf optionally comes with its own [Fish extension][]. It is substantial but `fzf
 [awesome fish]: https://git.io/awsm.fish
 [bat]: https://github.com/sharkdp/bat
 [brew]: https://brew.sh
+[cd docs]: https://fishshell.com/docs/current/cmds/cd.html
 [command history search]: images/command_history.gif
 [conf.d/fzf.fish]: conf.d/fzf.fish
 [fd]: https://github.com/sharkdp/fd

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -9,9 +9,8 @@ function __fzf_search_current_dir --description "Search the current directory us
 
     if test $status -eq 0
         # If this function was triggered with an empty commandline and the only thing selected is a directory, then
-        # prepend a dot and a slash to the folder. Because fish will attempt to cd implicitly if a directory name
-        # is provided with a dot at the beginning, this allows the user to hit Enter one more time to quickly cd
-        # in the selected directory.
+        # prepend ./ to the dir path. Because fish will attempt to cd implicitly if a directory name starting with a dot
+        # is provided, this allows the user to hit Enter one more time to quickly cd into the selected directory.
         if test (count (commandline -o)) = 0 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected
             set file_paths_selected ./$file_paths_selected
         end

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -8,6 +8,10 @@ function __fzf_search_current_dir --description "Search the current directory us
     )
 
     if test $status -eq 0
+        if test (count (commandline -poc)) = 0 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected[1]
+            set file_paths_selected[1] $file_paths_selected[1]/
+        end
+
         for path in $file_paths_selected
             set escaped_path (string escape "$path")
             commandline --insert "$escaped_path "

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -12,7 +12,7 @@ function __fzf_search_current_dir --description "Search the current directory us
         # prepend a dot and a slash to the folder. Because fish will attempt to cd implicitly if a directory name
         # is provided with a dot at the beginning, this allows the user to hit Enter one more time to quickly cd
         # in the selected directory.
-        if __fish_is_token_n 1 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected
+        if test (count (commandline -o)) = 0 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected
             set file_paths_selected ./$file_paths_selected
         end
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -11,7 +11,7 @@ function __fzf_search_current_dir --description "Search the current directory us
         # If this function was triggered with an empty commandline and the only thing selected is a directory, then
         # prepend ./ to the dir path. Because fish will attempt to cd implicitly if a directory name starting with a dot
         # is provided, this allows the user to hit Enter one more time to quickly cd into the selected directory.
-        if test (count (commandline -o)) = 0 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected
+        if test (count (commandline --tokenize)) = 0 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected
             set file_paths_selected ./$file_paths_selected
         end
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -8,7 +8,7 @@ function __fzf_search_current_dir --description "Search the current directory us
     )
 
     if test $status -eq 0
-        if test (count (commandline -poc)) = 0 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected[1]
+        if __fish_is_token_n 1 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected[1]
             set file_paths_selected[1] $file_paths_selected[1]/
         end
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -9,10 +9,11 @@ function __fzf_search_current_dir --description "Search the current directory us
 
     if test $status -eq 0
         # If this function was triggered with an empty commandline and the only thing selected is a directory, then
-        # append a slash to the folder. Because fish will attempt to cd implicitly if a directory name is provided with
-        # a / at the end, this allows the user to hit Enter one more time to quickly cd in the selected directory.
-        if __fish_is_token_n 1 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected[1]
-            set file_paths_selected[1] $file_paths_selected[1]/
+        # prepend a dot and a slash to the folder. Because fish will attempt to cd implicitly if a directory name
+        # is provided with a dot at the beginning, this allows the user to hit Enter one more time to quickly cd
+        # in the selected directory.
+        if __fish_is_token_n 1 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected
+            set file_paths_selected ./$file_paths_selected
         end
 
         for path in $file_paths_selected

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -8,6 +8,9 @@ function __fzf_search_current_dir --description "Search the current directory us
     )
 
     if test $status -eq 0
+        # If this function was triggered with an empty commandline and the only thing selected is a directory, then
+        # append a slash to the folder. Because fish will attempt to cd implicitly if a directory name is provided with
+        # a / at the end, this allows the user to hit Enter one more time to quickly cd in the selected directory.
         if __fish_is_token_n 1 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected[1]
             set file_paths_selected[1] $file_paths_selected[1]/
         end


### PR DESCRIPTION
This PR adds the following feature to File paths (<kbd>Ctrl</kbd> + <kbd>F</kbd>):

A dot and a slash (`./`) will be prepended automatically if:

- There is no input in the command line (the user triggers the function with a empty input)
- The user only made one selection
- The only selection is a directory

This makes it possible to quick enter the selected directory by pressing <kbd>Enter</kbd> again after making the selection. This is because [Fish treats it as implict `cd`](https://fishshell.com/docs/current/cmds/cd.html):

> Note that the shell will attempt to change directory without requiring cd if the name of a directory is provided (starting with ., / or ~, or ending with /).

<details>
<summary>
Screencast (Outdated)
</summary>

https://user-images.githubusercontent.com/44045911/103480545-e5b12580-4e0f-11eb-813a-13a2143a565f.mov
</details>

If the user changed their mind, they can do anything with the folder just like normal. ~~The trailing slash doesn't make much difference most of the time.~~