### PR TITLE
Always pre-populate fzf's search query with current token

### DIFF
--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -15,10 +15,7 @@ function __fzf_search_current_dir --description "Search the current directory us
             set file_paths_selected ./$file_paths_selected
         end
 
-        for path in $file_paths_selected
-            set escaped_path (string escape "$path")
-            commandline --current-token --replace "$escaped_path "
-        end
+        commandline --current-token --replace (string escape $file_paths_selected | string join ' ')
     end
 
     commandline --function repaint

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -4,13 +4,13 @@ function __fzf_search_current_dir --description "Search the current directory us
     set --local --export SHELL (command --search fish)
     set file_paths_selected (
         fd --hidden --color=always --exclude=.git 2>/dev/null |
-        fzf --multi --ansi --preview='__fzf_preview_file {}'
+        fzf --multi --ansi --preview='__fzf_preview_file {}' --query=(commandline --current-token)
     )
 
     if test $status -eq 0
         for path in $file_paths_selected
             set escaped_path (string escape "$path")
-            commandline --insert "$escaped_path "
+            commandline --current-token --replace "$escaped_path "
         end
     end
 

--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -10,12 +10,12 @@ function __fzf_search_git_log --description "Search the git log of the current g
             # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
             # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
             git log --color=always --format=format:'%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)' | \
-            fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]'
+            fzf --ansi --tiebreak=index --preview='git show --color=always (string split --max 1 " " {})[1]' --query=(commandline --current-token)
         )
         if test $status -eq 0
             set abbreviated_commit_hash (string split --max 1 " " $selected_log_line)[1]
             set commit_hash (git rev-parse $abbreviated_commit_hash)
-            commandline --insert $commit_hash
+            commandline --current-token --replace $commit_hash
         end
     end
 

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -10,18 +10,19 @@ function __fzf_search_git_status --description "Search the git status of the cur
         if test $status -eq 0
             # git status --short automatically escapes the paths of most files for us so not going to bother trying to handle
             # the few edges cases of weird file names that should be extremely rare (e.g. "this;needs;escaping")
+            set cleaned_paths
+
             for path in $selected_paths
                 if test (string sub --length 1 $path) = 'R'
                     # path has been renamed and looks like "R LICENSE -> LICENSE.md"
                     # extract the path to use from after the arrow
-                    set cleaned_path (string split -- "-> " $path)[-1]
+                    set --append cleaned_paths (string split -- "-> " $path)[-1]
                 else
-                    set cleaned_path (string sub --start=4 $path)
+                    set --append cleaned_paths (string sub --start=4 $path)
                 end
-                # add a space after each path to keep them separated when inserted
-                set cleaned_path_padded "$cleaned_path "
-                commandline --current-token --replace $cleaned_path_padded
             end
+
+            commandline --current-token --replace (string escape $cleaned_paths | string join ' ')
         end
     end
 

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -5,7 +5,7 @@ function __fzf_search_git_status --description "Search the git status of the cur
         set selected_paths (
             # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
             git -c color.status=always status --short |
-            fzf --ansi --multi
+            fzf --ansi --multi --query=(commandline --current-token)
         )
         if test $status -eq 0
             # git status --short automatically escapes the paths of most files for us so not going to bother trying to handle
@@ -20,7 +20,7 @@ function __fzf_search_git_status --description "Search the git status of the cur
                 end
                 # add a space after each path to keep them separated when inserted
                 set cleaned_path_padded "$cleaned_path "
-                commandline --insert $cleaned_path_padded
+                commandline --current-token --replace $cleaned_path_padded
             end
         end
     end

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -10,11 +10,16 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     # __echo_value_or_print_message will print an informative message in lieu of the value.
     set variable_name (
         set --names |
-        fzf --preview '__fzf_display_value_or_error {}'
+        fzf --preview '__fzf_display_value_or_error {}' \
+            --query=(commandline --current-token | read token && string replace '$' '' $token)
     )
 
     if test $status -eq 0
-        commandline --insert $variable_name
+        if string match -q '$*' $token
+            commandline --current-token --replace \$$variable_name
+        else
+            commandline --current-token --replace $variable_name
+        end
     end
 
     commandline --function repaint

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -8,8 +8,8 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     # of the selected variable in fzf's preview window.
     # Non-exported variables will not be accessible to the fzf process, in which case
     # __echo_value_or_print_message will print an informative message in lieu of the value.
-    # We use the current token to pre-populate fzf's search input. In case the user has typed
-    # a $, we remove it so that the current token will more likely match the variable names
+    # We use the current token to pre-populate fzf's query. If the current token begins
+    # with a $, we remove it from the query so that it will better match the variable names
     # and we put it back later when replacing the current token with the user's selection.
     set variable_name (
         set --names |
@@ -18,7 +18,8 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     )
 
     if test $status -eq 0
-        # If the user initially typed a $ before using this function
+        # If the current token begins with a $, make sure to keep it there when overwriting
+        # the current token with the user's selection.
         if string match -q '$*' (commandline --current-token)
             commandline --current-token --replace \$$variable_name
         else

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -11,11 +11,11 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     set variable_name (
         set --names |
         fzf --preview '__fzf_display_value_or_error {}' \
-            --query=(commandline --current-token | read token && string replace '$' '' $token)
+            --query=(commandline --current-token | string replace '$' '')
     )
 
     if test $status -eq 0
-        if string match -q '$*' $token
+        if string match -q '$*' (commandline --current-token)
             commandline --current-token --replace \$$variable_name
         else
             commandline --current-token --replace $variable_name

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -8,8 +8,9 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     # of the selected variable in fzf's preview window.
     # Non-exported variables will not be accessible to the fzf process, in which case
     # __echo_value_or_print_message will print an informative message in lieu of the value.
-    # set --names ouputs a list of variable names without $ prefix, so we remove the first
-    # $ from the initial query in case the user has typed one.
+    # We use the current token to pre-populate fzf's search input. In case the user has typed
+    # a $, we remove it so that the current token will more likely match the variable names
+    # and we put it back later when replacing the current token with the user's selection.
     set variable_name (
         set --names |
         fzf --preview '__fzf_display_value_or_error {}' \
@@ -17,8 +18,7 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     )
 
     if test $status -eq 0
-        # We may have removed the first $ above if the user has typed one, so we need to
-        # add it back.
+        # If the user initially typed a $ before using this function
         if string match -q '$*' (commandline --current-token)
             commandline --current-token --replace \$$variable_name
         else

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -8,6 +8,8 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     # of the selected variable in fzf's preview window.
     # Non-exported variables will not be accessible to the fzf process, in which case
     # __echo_value_or_print_message will print an informative message in lieu of the value.
+    # set --names ouputs a list of variable names without $ prefix, so we remove the first
+    # $ from the initial query in case the user has typed one.
     set variable_name (
         set --names |
         fzf --preview '__fzf_display_value_or_error {}' \
@@ -15,6 +17,8 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     )
 
     if test $status -eq 0
+        # We may have removed the first $ above if the user has typed one, so we need to
+        # add it back.
         if string match -q '$*' (commandline --current-token)
             commandline --current-token --replace \$$variable_name
         else

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -20,7 +20,7 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     if test $status -eq 0
         # If the current token begins with a $, make sure to keep it there when overwriting
         # the current token with the user's selection.
-        if string match -q '$*' (commandline --current-token)
+        if string match --quiet '$*' (commandline --current-token)
             commandline --current-token --replace \$$variable_name
         else
             commandline --current-token --replace $variable_name

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -18,8 +18,8 @@ function __fzf_search_shell_variables --description "Search and inspect shell va
     )
 
     if test $status -eq 0
-        # If the current token begins with a $, make sure to keep it there when overwriting
-        # the current token with the user's selection.
+        # If the current token begins with a $, do not overwrite the $ when 
+        # replacing the current token with the selected variable.
         if string match --quiet '$*' (commandline --current-token)
             commandline --current-token --replace \$$variable_name
         else


### PR DESCRIPTION
Currect only "A previously run command" uses existing input as fzf's default query. I think this should apply to all functions.

For variable searching I did some extra work for leading `$`:

https://user-images.githubusercontent.com/44045911/103555474-4feac880-4eeb-11eb-918c-97878fa43180.mov

