### PR TITLE
Clean up and consolidate changes for v5

### DIFF
--- a/functions/__fzf_extract_var_info.fish
+++ b/functions/__fzf_extract_var_info.fish
@@ -1,5 +1,5 @@
-# A helper function for __fzf_search_shell_variables
-function __fzf_extract_var_info --argument-names variable_name set_show_output --description "Extract the info for one variable from the output of set --show and simplify it."
+# helper function for __fzf_search_shell_variables
+function __fzf_extract_var_info --argument-names variable_name set_show_output --description "Extract lines pertaining to \$variable_name from \$set_show_output and simplify them."
     # Extract only the lines that begin with...
     # $variable_name: set
     # ...or...

--- a/functions/__fzf_extract_var_info.fish
+++ b/functions/__fzf_extract_var_info.fish
@@ -1,5 +1,5 @@
 # helper function for __fzf_search_shell_variables
-function __fzf_extract_var_info --argument-names variable_name set_show_output --description "Extract lines pertaining to \$variable_name from \$set_show_output and simplify them."
+function __fzf_extract_var_info --argument-names variable_name set_show_output --description "Extract and reformat lines pertaining to \$variable_name from \$set_show_output."
     # Extract only the lines that begin with...
     # $variable_name: set
     # ...or...

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -1,5 +1,5 @@
 # helper function for __fzf_search_current_dir
-function __fzf_preview_file --argument-names file_path --description "Prints a preview for the given file based on its file type."
+function __fzf_preview_file --argument-names file_path --description "Print a preview for the given file based on its file type."
     if test -f "$file_path" # regular file
         bat --style=numbers --color=always "$file_path"
     else if test -d "$file_path" # directory

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -1,4 +1,4 @@
-function __fzf_search_current_dir --description "Search the current directory using fzf and fd. Insert the selected relative file path into the commandline at the cursor."
+function __fzf_search_current_dir --description "Search the current directory. Replace the current token with the selected file paths."
     # Make sure that fzf uses fish to execute __fzf_preview_file.
     # See similar comment in __fzf_search_shell_variables.fish.
     set --local --export SHELL (command --search fish)

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -8,7 +8,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
     )
 
     if test $status -eq 0
-        # If this function was triggered with an empty commandline and the only thing selected is a directory, then
+        # If this function was triggered with an empty command line and the only thing selected is a directory, then
         # prepend ./ to the dir path. Because fish will attempt to cd implicitly if a directory name starting with a dot
         # is provided, this allows the user to hit Enter one more time to quickly cd into the selected directory.
         if test (count (commandline --tokenize)) = 0 && test (count $file_paths_selected) = 1 && test -d $file_paths_selected

--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -1,4 +1,4 @@
-function __fzf_search_git_log --description "Search the git log of the current git repository. Insert the selected commit hash into the commandline at the cursor."
+function __fzf_search_git_log --description "Search the output of git log and preview commits. Replace the current token with the selected commit hash."
     if not git rev-parse --git-dir >/dev/null 2>&1
         echo '__fzf_search_git_log: Not in a git repository.' >&2
     else

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -1,4 +1,4 @@
-function __fzf_search_git_status --description "Search the git status of the current git repository. Insert the selected file paths into the commandline at the cursor."
+function __fzf_search_git_status --description "Search the output of git status. Replace the current token with the selected file paths."
     if not git rev-parse --git-dir >/dev/null 2>&1
         echo '__fzf_search_git_status: Not in a git repository.' >&2
     else

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -1,4 +1,4 @@
-function __fzf_search_history --description "Search command history. Replace the commandline with the selected command."
+function __fzf_search_history --description "Search command history. Replace the command line with the selected command."
     # history merge incorporates history changes from other fish sessions
     builtin history merge
     set command_with_ts (

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -1,4 +1,4 @@
-function __fzf_search_history --description "Search command history using fzf. Replace the commandline with the selected command."
+function __fzf_search_history --description "Search command history. Replace the commandline with the selected command."
     # history merge incorporates history changes from other fish sessions
     builtin history merge
     set command_with_ts (

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -1,7 +1,7 @@
 # This function expects the following two arguments:
 # argument 1 = output of (set --show | psub), i.e. a file with the scope info and values of all variables
 # argument 2 = output of (set --names | psub), i.e. a file with all variable names
-function __fzf_search_shell_variables --argument-names set_show_output set_names_output --description "Search and inspect shell variables using fzf. Replace the current token with the selected variable."
+function __fzf_search_shell_variables --argument-names set_show_output set_names_output --description "Search and preview shell variables. Replace the current token with the selected variable."
     # inform users who use custom key bindings of the backwards incompatible change
     if test -z "$set_names_output"
         set_color red

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -15,7 +15,7 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
 
     # Make sure that fzf uses fish to execute __fzf_extract_var_info, which
     # is an autoloaded fish function so doesn't exist in other shells.
-    # Using --local so that it does not clobber SHELL outside of this function.
+    # Use --local so that it does not clobber SHELL outside of this function.
     set --local --export SHELL (command --search fish)
 
     # Exclude the history variable from being piped into fzf because
@@ -25,13 +25,14 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     set all_variable_names (string match --invert history <$set_names_output)
 
     set current_token (commandline --current-token)
-    # We use the current token to pre-populate fzf's query. If the current token begins
-    # with a $, we remove it from the query so that it will better match the variable names
-    # and we put it back later when replacing the current token with the user's selection.
+    # Use the current token to pre-populate fzf's query. If the current token begins
+    # with a $, remove it from the query so that it will better match the variable names
+    set cleaned_curr_token (string replace '$' '' $current_token)
+
     set variable_name (
         printf '%s\n' $all_variable_names |
         fzf --preview "__fzf_extract_var_info {} $set_show_output" \
-            --query=(string replace '$' '' $current_token)
+            --query=$cleaned_curr_token
     )
 
     if test $status -eq 0

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -24,19 +24,20 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     # 3.__fzf_search_history is a much better way to examine history anyway
     set all_variable_names (string match --invert history <$set_names_output)
 
+    set current_token (commandline --current-token)
     # We use the current token to pre-populate fzf's query. If the current token begins
     # with a $, we remove it from the query so that it will better match the variable names
     # and we put it back later when replacing the current token with the user's selection.
     set variable_name (
         printf '%s\n' $all_variable_names |
         fzf --preview "__fzf_extract_var_info {} $set_show_output" \
-            --query=(commandline --current-token | string replace '$' '')
+            --query=(string replace '$' '' $current_token)
     )
 
     if test $status -eq 0
         # If the current token begins with a $, do not overwrite the $ when
         # replacing the current token with the selected variable.
-        if string match --quiet '$*' (commandline --current-token)
+        if string match --quiet '$*' $current_token
             commandline --current-token --replace \$$variable_name
         else
             commandline --current-token --replace $variable_name


### PR DESCRIPTION
Clean up function descriptions using the following criteria
- don't mention fzf, that's already obvious in the name of the function
- rather than writing about the function, write the description as if it is pseudo-code that emulates what the function does
- use sentence casing, following the Python style guide (https://devguide.python.org/documenting/)
- mention when previewing is built in
- prefer "output of git command" over "git noun of current repository", which is shorter and maybe less abstract
- "command line" is the proper spelling, not "commandline"

Also, for search shell variable:
- consolidated calls to `commandline --current-token`
- refactored logic for cleaning current token onto its own line so its documentation can be right above it and the call to fzf is shorter