### PR TITLE
Prevent arguments from being interpreted as options

### DIFF
--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -9,7 +9,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
 
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
-    if string match --quiet "*/" $token && test -d $token
+    if string match --quiet -- "*/" $token && test -d $token
         set --append fd_arguments --base-directory=$token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --append fzf_arguments --prompt=$token --preview="__fzf_preview_file $token{}"
@@ -34,7 +34,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
             end
         end
 
-        commandline --current-token --replace (string escape $file_paths_selected | string join ' ')
+        commandline --current-token --replace -- (string escape -- $file_paths_selected | string join ' ')
     end
 
     commandline --function repaint

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -22,7 +22,7 @@ function __fzf_search_git_status --description "Search the output of git status.
                 end
             end
 
-            commandline --current-token --replace (string escape $cleaned_paths | string join ' ')
+            commandline --current-token --replace -- (string escape -- $cleaned_paths | string join ' ')
         end
     end
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -10,7 +10,7 @@ function __fzf_search_history --description "Search command history. Replace the
 
     if test $status -eq 0
         set command_selected (string split --max 1 " | " $command_with_ts)[2]
-        commandline --replace $command_selected
+        commandline --replace -- $command_selected
     end
 
     commandline --function repaint

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -27,7 +27,7 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     set current_token (commandline --current-token)
     # Use the current token to pre-populate fzf's query. If the current token begins
     # with a $, remove it from the query so that it will better match the variable names
-    set cleaned_curr_token (string replace '$' '' $current_token)
+    set cleaned_curr_token (string replace -- '$' '' $current_token)
 
     set variable_name (
         printf '%s\n' $all_variable_names |
@@ -38,7 +38,7 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     if test $status -eq 0
         # If the current token begins with a $, do not overwrite the $ when
         # replacing the current token with the selected variable.
-        if string match --quiet '$*' $current_token
+        if string match --quiet -- '$*' $current_token
             commandline --current-token --replace \$$variable_name
         else
             commandline --current-token --replace $variable_name


### PR DESCRIPTION
User inputs, file names and commands can contain leading hypens (`--`), which may cause errors or the function not working.

Examples where fzf.fish would error:
- the cursor is over the token --something when the user executes find file
- the selected changed path from git status is -folder
- the selected command is --function

The solution is to delineate the end of options with --, which is a POSIX specification defined in https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02 (guideline 10), which is respected by Fish builtins. After --, the command will always interpret the arguments as positional arguments.