### PR TITLE
Fix bug in extracting variable values containing |

### DIFF
--- a/functions/__fzf_extract_var_info.fish
+++ b/functions/__fzf_extract_var_info.fish
@@ -10,7 +10,7 @@ function __fzf_extract_var_info --argument-names variable_name set_show_output -
     # $variable_name: set in global scope
     # ...with...
     # set in global scope
-    string replace --regex "^\\\$$variable_name: " "" |
+    string replace --regex "^\\\$$variable_name: " '' |
 
     # From the lines of values, keep only the index and value, replacing...
     # $variable_name[1]: length=14 value=|variable_value|

--- a/functions/__fzf_extract_var_info.fish
+++ b/functions/__fzf_extract_var_info.fish
@@ -6,17 +6,17 @@ function __fzf_extract_var_info --argument-names variable_name set_show_output -
     # $variable_name[
     string match --entire --regex "^\\\$$variable_name(?:: set|\[)" <$set_show_output |
 
-    # Strip the variable name from the variable info, replacing...
+    # Strip the variable name from the scope info, replacing...
     # $variable_name: set in global scope
     # ...with...
     # set in global scope
-    string replace --regex "^\\\$$variable_name: " '' |
+    string replace --regex "^\\\$$variable_name: " "" |
 
     # From the lines of values, keep only the index and value, replacing...
     # $variable_name[1]: length=14 value=|variable_value|
     # ...with...
     # [1] variable_value
-    string replace --regex "^\\\$$variable_name(\[.+\]).+\|(.+)\|\$" '\$1 \$2'
+    string replace --regex "^\\\$$variable_name(\[\d+\]).+?\|(.+)\|\$" '\$1 \$2'
 
     # Final output example for $PATH:
     # set in global scope, unexported, with 5 elements

--- a/tests/extract_var_info_test.fish
+++ b/tests/extract_var_info_test.fish
@@ -1,0 +1,6 @@
+@echo === extract_var_info ===
+
+set --local variable "| a | b | c | d |"
+set --local output (__fzf_extract_var_info variable (set --show | psub) | string collect)
+@test "vars containing |" "$output" = "set in local scope, unexported, with 1 elements
+[1] | a | b | c | d |"

--- a/tests/extract_var_info_test.fish
+++ b/tests/extract_var_info_test.fish
@@ -1,6 +1,7 @@
 @echo === extract_var_info ===
 
 set --local variable "| a | b | c | d |"
-set --local output (__fzf_extract_var_info variable (set --show | psub) | string collect)
-@test "vars containing |" "$output" = "set in local scope, unexported, with 1 elements
+set --local actual (__fzf_extract_var_info variable (set --show | psub) | string collect)
+set --local expected "set in local scope, unexported, with 1 elements
 [1] | a | b | c | d |"
+@test "vars containing '|'" "$actual" = $expected

--- a/tests/extract_var_info_test.fish
+++ b/tests/extract_var_info_test.fish
@@ -4,4 +4,4 @@ set --local variable "| a | b | c | d |"
 set --local actual (__fzf_extract_var_info variable (set --show | psub) | string collect)
 set --local expected "set in local scope, unexported, with 1 elements
 [1] | a | b | c | d |"
-@test "vars containing '|'" "$actual" = $expected
+@test "vars containing '|'" $actual = $expected


### PR DESCRIPTION
The bug happens whenever the variable being previewed contains `|`. What happens is that the third regex used in `__fzf_extract_var_info` is greedy and will over-remove text up until the second to last `|`. For example:
```
$ set variable "a | b | c | d"
$ __fzf_extract_var_info variable (set --show | psub)
set in global scope, unexported, with 1 elements
[1]  d
```

With these changes, it now works properly:
```
$ set variable "a | b | c | d"
$ __fzf_extract_var_info variable (set --show | psub)
set in global scope, unexported, with 1 elements
[1] a | b | c | d
```

Additionally, I've added a Fishtape test to make debugging these tricky regexes more easily in the future, which I expect to need to do as fish shell on master has changed the output of `set --show`.