### PR TITLE
Add tests for search shell variables

### DIFF
--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -5,12 +5,12 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     # inform users who use custom key bindings of the backwards incompatible change
     if test -z "$set_names_output"
         set_color red
-        printf '\n%s\n' '__fzf_search_shell_variables now requires arguments so you have to update your key bindings.'
-        printf '%s\n\n' 'Please see github.com/PatrickF1/fzf.fish/releases/tag/v5.0 for the resolution.'
+        printf '\n%s\n' '__fzf_search_shell_variables now requires arguments so you have to update your key bindings.' >&2
+        printf '%s\n\n' 'Please see github.com/PatrickF1/fzf.fish/releases/tag/v5.0 for the resolution.' >&2
         set_color normal
 
         commandline --function repaint
-        return 1
+        return 22 # 22 means invalid argument in POSIX
     end
 
     # Make sure that fzf uses fish to execute __fzf_extract_var_info, which

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -10,7 +10,7 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
         set_color normal
 
         commandline --function repaint
-        return
+        return 1
     end
 
     # Make sure that fzf uses fish to execute __fzf_extract_var_info, which

--- a/tests/extract_var_info_test.fish
+++ b/tests/extract_var_info_test.fish
@@ -2,6 +2,5 @@
 
 set --local variable "| a | b | c | d |"
 set --local actual (__fzf_extract_var_info variable (set --show | psub) | string collect)
-set --local expected "set in local scope, unexported, with 1 elements
-[1] | a | b | c | d |"
+set --local expected "set in local scope, unexported, with 1 elements"\n"[1] | a | b | c | d |"
 @test "vars containing '|'" $actual = $expected

--- a/tests/search_shell_variables.fish
+++ b/tests/search_shell_variables.fish
@@ -10,4 +10,7 @@ set --local actual (eval $search_vars_cmd)
 @test "searches local variables" $actual = a_local_variable
 set --erase a_local_variable
 set --erase --local FZF_DEFAULT_OPTS
-set --show FZF_DEFAULT_OPTS
+
+mock fzf \* "" # do nothing if we reach fzf so we don't get stuck
+__fzf_search_shell_variables
+@test "fails if no arguments given" $status -eq 1

--- a/tests/search_shell_variables.fish
+++ b/tests/search_shell_variables.fish
@@ -12,5 +12,10 @@ set --erase a_local_variable
 set --erase --local FZF_DEFAULT_OPTS
 
 mock fzf \* "" # do nothing if we reach fzf so we don't get stuck
-__fzf_search_shell_variables
-@test "fails if no arguments given" $status -eq 1
+__fzf_search_shell_variables 2>/dev/null
+@test "fails if no arguments given" $status -ne 0
+
+mock commandline --current-token "echo \\\$variable"
+mock fzf \* "echo selection"
+set actual (eval $search_vars_cmd)
+@test "doesn't overwrite \$ when replacing current token with selected variable" $actual = "\$selection"

--- a/tests/search_shell_variables.fish
+++ b/tests/search_shell_variables.fish
@@ -2,7 +2,8 @@
 
 set --local a_local_variable
 set --local --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
-mock commandline \* "echo \$argv"
+mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
+mock commandline \* "" # mock everything else to do nothing
 set --local actual (__fzf_search_shell_variables (set --show | psub) (set --names | psub))
 
 @test "searches local variables" $actual = a_local_variable

--- a/tests/search_shell_variables.fish
+++ b/tests/search_shell_variables.fish
@@ -2,11 +2,10 @@
 
 set --local a_local_variable
 set --local --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
-mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
-mock commandline \* "" # mock everything else to do nothing
+mock commandline "--current-token --replace" "echo done" # instead of updating commandline with the result, just output it
+mock commandline \* "echo test" # mock everything else to do nothing
 # grab the command used to execute search shell directly from the bindings
-set --local search_vars_binding (bind \cv)[2]
+set --local search_vars_binding (bind --user \cv)
 set --local search_vars_cmd (echo $search_vars_binding | cut -d" " -f 3- | string unescape)
 set --local actual (eval $search_vars_cmd)
-
 @test "searches local variables" $actual = a_local_variable

--- a/tests/search_shell_variables.fish
+++ b/tests/search_shell_variables.fish
@@ -2,10 +2,12 @@
 
 set --local a_local_variable
 set --local --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
-mock commandline "--current-token --replace" "echo done" # instead of updating commandline with the result, just output it
-mock commandline \* "echo test" # mock everything else to do nothing
+mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
+mock commandline \* "" # mock all other commandline executions to do nothing
 # grab the command used to execute search shell directly from the bindings
-set --local search_vars_binding (bind --user \cv)
-set --local search_vars_cmd (echo $search_vars_binding | cut -d" " -f 3- | string unescape)
+set --local search_vars_cmd (bind --user \cv | cut -d" " -f 3- | string unescape)
 set --local actual (eval $search_vars_cmd)
 @test "searches local variables" $actual = a_local_variable
+set --erase a_local_variable
+set --erase --local FZF_DEFAULT_OPTS
+set --show FZF_DEFAULT_OPTS

--- a/tests/search_shell_variables.fish
+++ b/tests/search_shell_variables.fish
@@ -1,0 +1,8 @@
+@echo === search_shell_variables ===
+
+set --local a_local_variable
+set --local --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
+mock commandline \* "echo \$argv"
+set --local actual (__fzf_search_shell_variables (set --show | psub) (set --names | psub))
+
+@test "searches local variables" $actual = a_local_variable

--- a/tests/search_shell_variables.fish
+++ b/tests/search_shell_variables.fish
@@ -4,6 +4,9 @@ set --local a_local_variable
 set --local --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
 mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
 mock commandline \* "" # mock everything else to do nothing
-set --local actual (__fzf_search_shell_variables (set --show | psub) (set --names | psub))
+# grab the command used to execute search shell directly from the bindings
+set --local search_vars_binding (bind \cv)[2]
+set --local search_vars_cmd (echo $search_vars_binding | cut -d" " -f 3- | string unescape)
+set --local actual (eval $search_vars_cmd)
 
 @test "searches local variables" $actual = a_local_variable


### PR DESCRIPTION
Adding Fishtape tests using Clownfish to mock commandline and fzf.