### PR TITLE
Expand tilde while searching files

### DIFF
--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -6,11 +6,12 @@ function __fzf_search_current_dir --description "Search the current directory. R
     set fd_arguments --hidden --color=always --exclude=.git
     set fzf_arguments --multi --ansi
     set token (commandline --current-token | string unescape)
+    set expanded_token (string replace --regex -- "^~/" $HOME/ $token)
 
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
-    if string match --quiet -- "*/" $token && test -d $token
-        set --append fd_arguments --base-directory=$token
+    if string match --quiet -- "*/" $token && test -d $expanded_token
+        set --append fd_arguments --base-directory=$expanded_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --append fzf_arguments --prompt=$token --preview="__fzf_preview_file $token{}"
         set file_paths_selected $token(fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)


### PR DESCRIPTION
Fix #88 

Fish's `test` and `fd` doesn't expand `~` automatically, so we need to expand it ourselves.

![image](https://user-images.githubusercontent.com/44045911/106351183-a0e8b380-6315-11eb-95a7-27999d2f545a.png)
