### PR TITLE
Refactor: one folder per test suite, one file per test case

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,7 +29,7 @@ jobs:
           ~/.fzf/install
 
       - name: Run full test suite
-        run: fishtape tests/*
+        run: fishtape tests/*/*
         shell: fish {0}
       - name: Test
         run: echo $HOME

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,3 +31,6 @@ jobs:
       - name: Run full test suite
         run: fishtape tests/*
         shell: fish {0}
+      - name: Test
+        run: echo $HOME
+        shell: fish {0}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -32,5 +32,7 @@ jobs:
         run: fishtape tests/*/*
         shell: fish {0}
       - name: Test
-        run: echo $HOME
+        run: |
+          echo $HOME
+          ls -a -R $HOME
         shell: fish {0}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,8 +31,3 @@ jobs:
       - name: Run full test suite
         run: fishtape tests/*/*
         shell: fish {0}
-      - name: Test
-        run: |
-          echo $HOME
-          ls -a -R $HOME
-        shell: fish {0}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # fzf.fish 🔍🐟
 
-[![latest release badge][]][releases] [![fish version badge][]](#installation) [![awesome badge][]][awesome fish]
+[![latest release badge][]][releases] [![build status badge][]][actions] [![awesome badge][]][awesome fish]
 
 </div>
 
@@ -130,17 +130,18 @@ Need help? These Wiki pages can guide you:
 - [Troubleshooting][troubleshooting]
 - [FAQ][faq]
 
+[actions]: https://github.com/PatrickF1/fzf.fish/actions
 [awesome badge]: https://awesome.re/mentioned-badge.svg
 [awesome fish]: https://git.io/awsm.fish
 [bat]: https://github.com/sharkdp/bat
 [brew]: https://brew.sh
+[build status badge]: https://img.shields.io/github/workflow/status/patrickf1/fzf.fish/CI
 [cd docs]: https://fishshell.com/docs/current/cmds/cd.html
 [command history search]: images/command_history.gif
 [conf.d/fzf.fish]: conf.d/fzf.fish
 [faq]: https://github.com/PatrickF1/fzf.fish/wiki/FAQ
 [fd]: https://github.com/sharkdp/fd
 [file search]: images/directory.gif
-[fish version badge]: https://img.shields.io/badge/fish-v3.1.2%2B-green
 [Fish]: http://fishshell.com
 [Fisher]: https://github.com/jorgebucaran/fisher
 [Fish extension]: https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -3,12 +3,13 @@ if not set --query fzf_fish_custom_keybindings
     # Because of scoping rules, to capture the shell variables exactly as they are, we must read
     # them before even executing __fzf_search_shell_variables. We use psub to store the
     # variables' info in temporary files and pass in the filenames as arguments.
-    set --local search_vars_cmd '__fzf_search_shell_variables (set --show | psub) (set --names | psub)'
+    # Making this variable global so that it can be used by users customizing key bindings and tests
+    set __fzf_vars_cmd '__fzf_search_shell_variables (set --show | psub) (set --names | psub)'
 
     # \cf is Ctrl+f
     bind \cf '__fzf_search_current_dir'
     bind \cr '__fzf_search_history'
-    bind \cv $search_vars_cmd
+    bind \cv $__fzf_vars_cmd
     # The following two key binding use Alt as an additional modifier key to avoid conflicts
     bind \e\cl '__fzf_search_git_log'
     bind \e\cs '__fzf_search_git_status'
@@ -17,7 +18,7 @@ if not set --query fzf_fish_custom_keybindings
     if test "$fish_key_bindings" = 'fish_vi_key_bindings'
         bind --mode insert \cf '__fzf_search_current_dir'
         bind --mode insert \cr '__fzf_search_history'
-        bind --mode insert \cv $search_vars_cmd
+        bind --mode insert \cv $__fzf_vars_cmd
         bind --mode insert \e\cl '__fzf_search_git_log'
         bind --mode insert \e\cs '__fzf_search_git_status'
     end

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -1,15 +1,15 @@
+# Because of scoping rules, to capture the shell variables exactly as they are, we must read
+# them before even executing __fzf_search_shell_variables. We use psub to store the
+# variables' info in temporary files and pass in the filenames as arguments.
+# This variable is intentionally global so that it can be referenced by custom key bindings and tests
+set __fzf_search_vars_cmd '__fzf_search_shell_variables (set --show | psub) (set --names | psub)'
+
 # Set up the default, mnemonic key bindings unless the user has chosen to customize them
 if not set --query fzf_fish_custom_keybindings
-    # Because of scoping rules, to capture the shell variables exactly as they are, we must read
-    # them before even executing __fzf_search_shell_variables. We use psub to store the
-    # variables' info in temporary files and pass in the filenames as arguments.
-    # Making this variable global so that it can be used by users customizing key bindings and tests
-    set __fzf_vars_cmd '__fzf_search_shell_variables (set --show | psub) (set --names | psub)'
-
     # \cf is Ctrl+f
     bind \cf '__fzf_search_current_dir'
     bind \cr '__fzf_search_history'
-    bind \cv $__fzf_vars_cmd
+    bind \cv $__fzf_search_vars_cmd
     # The following two key binding use Alt as an additional modifier key to avoid conflicts
     bind \e\cl '__fzf_search_git_log'
     bind \e\cs '__fzf_search_git_status'
@@ -18,7 +18,7 @@ if not set --query fzf_fish_custom_keybindings
     if test "$fish_key_bindings" = 'fish_vi_key_bindings'
         bind --mode insert \cf '__fzf_search_current_dir'
         bind --mode insert \cr '__fzf_search_history'
-        bind --mode insert \cv $__fzf_vars_cmd
+        bind --mode insert \cv $__fzf_search_vars_cmd
         bind --mode insert \e\cl '__fzf_search_git_log'
         bind --mode insert \e\cs '__fzf_search_git_status'
     end

--- a/tests/extract_var_info/vars_containing_pipe.fish
+++ b/tests/extract_var_info/vars_containing_pipe.fish
@@ -1,4 +1,4 @@
-set --local variable "| a | b | c | d |"
-set --local actual (__fzf_extract_var_info variable (set --show | psub) | string collect)
-set --local expected "set in local scope, unexported, with 1 elements"\n"[1] | a | b | c | d |"
+set variable "| a | b | c | d |"
+set actual (__fzf_extract_var_info variable (set --show | psub) | string collect)
+set expected "set in global scope, unexported, with 1 elements"\n"[1] | a | b | c | d |"
 @test "vars containing '|'" $actual = $expected

--- a/tests/extract_var_info/vars_containing_pipe.fish
+++ b/tests/extract_var_info/vars_containing_pipe.fish
@@ -1,5 +1,3 @@
-@echo === extract_var_info ===
-
 set --local variable "| a | b | c | d |"
 set --local actual (__fzf_extract_var_info variable (set --show | psub) | string collect)
 set --local expected "set in local scope, unexported, with 1 elements"\n"[1] | a | b | c | d |"

--- a/tests/search_current_dir/expands_~_base_dir.fish
+++ b/tests/search_current_dir/expands_~_base_dir.fish
@@ -1,7 +1,0 @@
-# mock everything so that the only thing that gets sent to stdout are the args passed into fd
-mock fd \* "echo \$argv"
-mock fzf \* ""
-mock commandline --current-token "echo ~/"
-mock commandline \* ""
-set fd_args (__fzf_search_current_dir)
-@test "~/ is expanded to $HOME" -z (string match --invert "~" $fd_args)

--- a/tests/search_current_dir/expands_~_base_dir.fish
+++ b/tests/search_current_dir/expands_~_base_dir.fish
@@ -1,0 +1,7 @@
+# mock everything so that the only thing that gets sent to stdout are the args passed into fd
+mock fd \* "echo \$argv"
+mock fzf \* ""
+mock commandline --current-token "echo ~/"
+mock commandline \* ""
+set fd_args (__fzf_search_current_dir)
+@test "~/ is expanded to $HOME" -z (string match --invert "~" $fd_args)

--- a/tests/search_shell_variables/$_in_curr_token.fish
+++ b/tests/search_shell_variables/$_in_curr_token.fish
@@ -1,0 +1,8 @@
+mock commandline \* "" # mock all other commandline executions to do nothing
+mock commandline --current-token "echo \\\$variable"
+mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
+mock fzf \* "echo selection"
+
+set --local search_vars_cmd (bind --user \cv | cut -d" " -f 3- | string unescape)
+set actual (eval $search_vars_cmd)
+@test "doesn't overwrite \$ when replacing current token with selected variable" $actual = "\$selection"

--- a/tests/search_shell_variables/$_in_curr_token.fish
+++ b/tests/search_shell_variables/$_in_curr_token.fish
@@ -3,6 +3,5 @@ mock commandline --current-token "echo \\\$variable"
 mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
 mock fzf \* "echo selection"
 
-set --local search_vars_cmd (bind --user \cv | cut -d" " -f 3- | string unescape)
-set actual (eval $search_vars_cmd)
+set actual (eval $__fzf_vars_cmd)
 @test "doesn't overwrite \$ when replacing current token with selected variable" $actual = "\$selection"

--- a/tests/search_shell_variables/local_var.fish
+++ b/tests/search_shell_variables/local_var.fish
@@ -2,7 +2,5 @@ set --local a_local_variable
 set --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
 mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
 mock commandline \* "" # mock all other commandline executions to do nothing
-# grab the command used to execute search shell directly from the bindings
-set search_vars_cmd (bind --user \cv | cut -d" " -f 3- | string unescape)
-set actual (eval $search_vars_cmd)
-@test "searches local variables" $actual = a_local_variable
+set actual (eval $__fzf_vars_cmd)
+@test "can find a local variable" $actual = a_local_variable

--- a/tests/search_shell_variables/local_variables.fish
+++ b/tests/search_shell_variables/local_variables.fish
@@ -1,8 +1,8 @@
 set --local a_local_variable
-set --local --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
+set --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
 mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
 mock commandline \* "" # mock all other commandline executions to do nothing
 # grab the command used to execute search shell directly from the bindings
-set --local search_vars_cmd (bind --user \cv | cut -d" " -f 3- | string unescape)
-set --local actual (eval $search_vars_cmd)
+set search_vars_cmd (bind --user \cv | cut -d" " -f 3- | string unescape)
+set actual (eval $search_vars_cmd)
 @test "searches local variables" $actual = a_local_variable

--- a/tests/search_shell_variables/local_variables.fish
+++ b/tests/search_shell_variables/local_variables.fish
@@ -1,5 +1,3 @@
-@echo === search_shell_variables ===
-
 set --local a_local_variable
 set --local --export --append FZF_DEFAULT_OPTS "--filter=a_local_variable"
 mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
@@ -8,14 +6,3 @@ mock commandline \* "" # mock all other commandline executions to do nothing
 set --local search_vars_cmd (bind --user \cv | cut -d" " -f 3- | string unescape)
 set --local actual (eval $search_vars_cmd)
 @test "searches local variables" $actual = a_local_variable
-set --erase a_local_variable
-set --erase --local FZF_DEFAULT_OPTS
-
-mock fzf \* "" # do nothing if we reach fzf so we don't get stuck
-__fzf_search_shell_variables 2>/dev/null
-@test "fails if no arguments given" $status -ne 0
-
-mock commandline --current-token "echo \\\$variable"
-mock fzf \* "echo selection"
-set actual (eval $search_vars_cmd)
-@test "doesn't overwrite \$ when replacing current token with selected variable" $actual = "\$selection"

--- a/tests/search_shell_variables/no_args.fish
+++ b/tests/search_shell_variables/no_args.fish
@@ -1,0 +1,3 @@
+mock fzf \* "" # do nothing if we reach fzf so we don't get stuck
+__fzf_search_shell_variables 2>/dev/null
+@test "fails if no arguments given" $status -ne 0


### PR DESCRIPTION
1. Put each test in its own file. From fishtape docs
> Each test file runs inside its own shell, so you can modify the global environment without cluttering your session or breaking other tests

2. Stopped making all the variables local, since I realized they won't pollute the session running the tests.
3. Replaced fish version badge with build status badge