### PR TITLE
Automate smoke tests for every feature

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # need to fetch all commits for now for the sake of search git log test
           fetch-depth: 0
       - uses: fish-actions/install-fish@v1.1.0
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+          fetch-depth: 0
       - uses: fish-actions/install-fish@v1.1.0
 
       - uses: fish-actions/fisher@v1

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
           fetch-depth: 0
       - uses: fish-actions/install-fish@v1.1.0
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,9 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          # need to fetch all commits for now for the sake of search git log test
-          fetch-depth: 0
       - uses: fish-actions/install-fish@v1.1.0
 
       - uses: fish-actions/fisher@v1

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -23,6 +23,6 @@ function __fzf_preview_file --argument-names file_path --description "Print a pr
     else if test -p "$file_path"
         __fzf_report_file_type "$file_path" "named pipe"
     else
-        echo "Unknown file type." >&2
+        echo "File doesn't exist." >&2
     end
 end

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -6,11 +6,12 @@ function __fzf_search_current_dir --description "Search the current directory. R
     set fd_arguments --hidden --color=always --exclude=.git
     set fzf_arguments --multi --ansi
     set token (commandline --current-token | string unescape)
-    set expanded_token (string replace --regex -- "^~/" $HOME/ $token)
 
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
     if string match --quiet -- "*/" $token && test -d $expanded_token
+        # need to expand ~ in the directory name since fd can't expand it
+        set expanded_token (string replace --regex -- "^~/" $HOME/ $token)
         set --append fd_arguments --base-directory=$expanded_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --append fzf_arguments --prompt=$token --preview="__fzf_preview_file $token{}"

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -6,12 +6,12 @@ function __fzf_search_current_dir --description "Search the current directory. R
     set fd_arguments --hidden --color=always --exclude=.git
     set fzf_arguments --multi --ansi
     set token (commandline --current-token | string unescape)
+    # need to expand ~ in the directory name since fd can't expand it
+    set expanded_token (string replace --regex -- "^~/" $HOME/ $token)
 
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
     if string match --quiet -- "*/" $token && test -d $expanded_token
-        # need to expand ~ in the directory name since fd can't expand it
-        set expanded_token (string replace --regex -- "^~/" $HOME/ $token)
         set --append fd_arguments --base-directory=$expanded_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --append fzf_arguments --prompt=$token --preview="__fzf_preview_file $token{}"

--- a/tests/preview_file/follows_sym_links.fish
+++ b/tests/preview_file/follows_sym_links.fish
@@ -1,0 +1,8 @@
+set pipe pipe_file
+set sym_link sym_linked_file
+mkfifo $pipe
+ln -s $pipe $sym_link
+
+set actual (__fzf_preview_file $sym_link)
+@test "follows symbolic links" -n (string match --entire "named pipe" $actual)
+rm $sym_link $pipe

--- a/tests/preview_file/ls_hidden_without_double_dot.fish
+++ b/tests/preview_file/ls_hidden_without_double_dot.fish
@@ -1,0 +1,2 @@
+set actual (__fzf_preview_file . | string split " ")
+@test "displays dir contents without showing .." -z (string match ".." $actual)

--- a/tests/search_current_dir/expands_~_base_dir.fish
+++ b/tests/search_current_dir/expands_~_base_dir.fish
@@ -1,8 +1,11 @@
-# mock everything so that the only thing that gets sent to stdout are the args passed into fd
-mock fd \* "echo \$argv"
+set --export fd_args
+function fd
+    set fd_args $argv
+    return 0
+end
 mock fzf \* ""
 mock commandline --current-token "echo ~/"
 mock commandline \* ""
-set fd_args (__fzf_search_current_dir)
-@test "~/ not in fd args" -z (string match "~/" $fd_args)
-@test "~/ is expanded to $HOME" -n (string match --entire "$HOME" $fd_args)
+__fzf_search_current_dir
+set expected_arg "--base-directory=$HOME"
+@test "~/ is expanded to HOME" -n (string match --entire -- $expected_arg $fd_args)

--- a/tests/search_current_dir/expands_~_base_dir.fish
+++ b/tests/search_current_dir/expands_~_base_dir.fish
@@ -1,10 +1,10 @@
 set --export fd_args
 function fd
     set fd_args $argv
-    return 0
 end
 mock fzf \* ""
 mock commandline --current-token "echo ~/"
+mock commandline "--current-token --replace" ""
 mock commandline \* ""
 __fzf_search_current_dir
 set expected_arg "--base-directory=$HOME"

--- a/tests/search_current_dir/expands_~_base_dir.fish
+++ b/tests/search_current_dir/expands_~_base_dir.fish
@@ -1,0 +1,8 @@
+# mock everything so that the only thing that gets sent to stdout are the args passed into fd
+mock fd \* "echo \$argv"
+mock fzf \* ""
+mock commandline --current-token "echo ~/"
+mock commandline \* ""
+set fd_args (__fzf_search_current_dir)
+@test "~/ not in fd args" -z (string match "~/" $fd_args)
+@test "~/ is expanded to $HOME" -n (string match --entire "$HOME" $fd_args)

--- a/tests/search_current_dir/no_base_dir_if_no_slash.fish
+++ b/tests/search_current_dir/no_base_dir_if_no_slash.fish
@@ -1,0 +1,14 @@
+set --export fd_args
+function fd
+    set fd_args $argv
+end
+mock fzf \* ""
+mock commandline --current-token "echo functions"
+mock commandline "--current-token --replace" ""
+mock commandline \* ""
+__fzf_search_current_dir
+if test -d functions
+    @test "doesn't change fd's base directory if no slash on current token" -z (string match --entire -- "--base-directory" $fd_args)
+else
+    @test "functions/ exists for testing purposes"
+end

--- a/tests/search_git_log/outputs_right_commit.fish
+++ b/tests/search_git_log/outputs_right_commit.fish
@@ -1,6 +1,17 @@
+# This test has two versions:  one for CI and one for local
 mock commandline "--current-token --replace" "echo \$argv"
 mock commandline \* ""
-set --export --append FZF_DEFAULT_OPTS "--filter='Refactor: one folder per test suite, one file per test case'"
-set expected "6c558feee95c34ce82ded8e08d98f5f73d0f9b97"
-set actual (__fzf_search_git_log)
-@test "Outputs right commit" $actual = $expected
+if git cat-file -e c6326dbda6b1f48ecbd015838073213be3bf6ec1 2>/dev/null # sha is a random commit that CI wouldn't pull
+    # This test is running locally.
+    set --export --append FZF_DEFAULT_OPTS "--filter='Refactor: one folder per test suite, one file per test case'"
+    set expected "6c558feee95c34ce82ded8e08d98f5f73d0f9b97"
+    set actual (__fzf_search_git_log)
+    @test "Outputs right commit (local)" $actual = $expected
+else
+    # This test is running on CI. Since we don't want to have CI download the entire git log just
+    # for a few tests, we will just test if it is able to output the sha of the only commit available
+    # by forcing fzf to select only commit available and checking if the ouputted sha exists
+    set --export --append FZF_DEFAULT_OPTS "--select-1"
+    git cat-file -e (__fzf_search_git_log) 2>/dev/null
+    @test "Outputs a valid git sha (CI)" $status -eq 0
+end

--- a/tests/search_git_log/outputs_right_commit.fish
+++ b/tests/search_git_log/outputs_right_commit.fish
@@ -1,0 +1,6 @@
+mock commandline "--current-token --replace" "echo \$argv"
+mock commandline \* ""
+set --export --append FZF_DEFAULT_OPTS "--filter='Refactor: one folder per test suite, one file per test case'"
+set expected "6c558feee95c34ce82ded8e08d98f5f73d0f9b97"
+set actual (__fzf_search_git_log)
+@test "Outputs right commit" $actual = $expected

--- a/tests/search_git_status/outputs_right_paths.fish
+++ b/tests/search_git_status/outputs_right_paths.fish
@@ -1,0 +1,12 @@
+set files "filename with space" "filename with \"\""
+touch $files
+git add --all
+mock commandline \* ""
+mock commandline "--current-token --replace --" "echo \$argv"
+__fzf_search_git_status
+set --export --append FZF_DEFAULT_OPTS "--filter="
+set actual (__fzf_search_git_status)
+
+@test "outputs correct paths" $actual = $files
+
+git reset --hard

--- a/tests/search_git_status/outputs_right_paths.fish
+++ b/tests/search_git_status/outputs_right_paths.fish
@@ -4,6 +4,7 @@ mock commandline \* ""
 mock commandline "--current-token --replace --" "echo \$argv"
 set --export --append FZF_DEFAULT_OPTS "--filter='filename'"
 set actual (__fzf_search_git_status)
-@test "outputs correct paths" (string unescape $actual) = "$files"
+string match $files[1] --entire -q $actual && string match --entire -q $files[2] $actual
+@test "correct paths found in output" $status -eq 0
 
 rm $files

--- a/tests/search_git_status/outputs_right_paths.fish
+++ b/tests/search_git_status/outputs_right_paths.fish
@@ -1,12 +1,9 @@
-set files "filename with space" "filename with \"\""
+set files "filename_with_*.txt" "filename with space.csv"
 touch $files
-git add --all
 mock commandline \* ""
 mock commandline "--current-token --replace --" "echo \$argv"
-__fzf_search_git_status
-set --export --append FZF_DEFAULT_OPTS "--filter="
+set --export --append FZF_DEFAULT_OPTS "--filter='filename'"
 set actual (__fzf_search_git_status)
+@test "outputs correct paths" (string unescape $actual) = "$files"
 
-@test "outputs correct paths" $actual = $files
-
-git reset --hard
+rm $files

--- a/tests/search_history/multi_line_cmd.fish
+++ b/tests/search_history/multi_line_cmd.fish
@@ -1,0 +1,25 @@
+# force history to read from a file with pre-populated history
+set fish_history test
+set history_file_path ~/.local/share/fish/test_history
+printf "%s" "- cmd: z fzf
+when: 1612201432
+- cmd: git log
+when: 1612201440
+- cmd: git status
+when: 1612201444
+- cmd: function select_me\necho I\\'m just testing\nend
+  when: 1612201475
+- cmd: history
+  when: 1612201479
+- cmd: cd ~/.local/share/fish/
+  when: 1612201487" >$history_file_path
+
+mock commandline "--replace --" "echo \$argv"
+mock commandline \* ""
+set --export --append FZF_DEFAULT_OPTS "--filter=function"
+# for some reason, \n doesn't appear in what is passed to commandline --replace --
+set expected "function select_me echo I\'m just testing end"
+set actual (__fzf_search_history)
+@test "ouputs right command" $actual = $expected
+
+rm $history_file_path


### PR DESCRIPTION
While I can't and don't plan on trying to test every possible code path, I can at least set up smoke tests. These smoke tests should catch many cases where a regression would completely break a feature, and thus prevent regressions from getting merged in. So while it won't obviate manual testing, it will cut down on manual testing for both me and anyone who wants to contribute to fzf.fish!