### PR TITLE
Fix search file feature unnecessarily prepending ./

### DIFF
--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -23,6 +23,6 @@ function __fzf_preview_file --argument-names file_path --description "Print a pr
     else if test -p "$file_path"
         __fzf_report_file_type "$file_path" "named pipe"
     else
-        echo "File doesn't exist." >&2
+        echo "File doesn't exist or is empty." >&2
     end
 end

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -15,7 +15,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
         set --append fd_arguments --base-directory=$expanded_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --append fzf_arguments --prompt=$token --preview="__fzf_preview_file $token{}"
-        set file_paths_selected $token(fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
+        set file_paths_selected $expanded_token(fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
     else
         set --append fzf_arguments --query=$token --preview='__fzf_preview_file {}'
         set file_paths_selected (fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -29,10 +29,12 @@ function __fzf_search_current_dir --description "Search the current directory. R
         # - if the path is a directory, the user can hit Enter one more time to immediately cd into it (fish will
         #   attempt to cd implicitly if a directory name starts with a dot)
         if test (count $file_paths_selected) = 1
-            set commandline_tokens (commandline --tokenize)
-            set current_token (commandline --current-token)
-            if test "$commandline_tokens" = "$current_token"
-                set file_paths_selected ./$file_paths_selected
+            if string match --invert "^/" $file_path_selected[1]
+                set commandline_tokens (commandline --tokenize)
+                set current_token (commandline --current-token)
+                if test "$commandline_tokens" = "$current_token"
+                    set file_paths_selected ./$file_paths_selected
+                end
             end
         end
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -16,7 +16,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
         set --append fd_arguments --base-directory=$expanded_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --append fzf_arguments --prompt=$token --preview="__fzf_preview_file $token{}"
-        set file_paths_selected $token(fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
+        set file_paths_selected $expanded_token(fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
     else
         set --append fzf_arguments --query=$token --preview='__fzf_preview_file {}'
         set file_paths_selected (fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
@@ -25,14 +25,14 @@ function __fzf_search_current_dir --description "Search the current directory. R
 
     if test $status -eq 0
         # Fish will implicitly take action on a path when a path is provided as the first token and it
-        # begins with a dot, slash, or tilde. If the path is a directory, Fish will cd into it.
-        # If the path is an executable, Fish will execute it. To help users harness
-        # this convenient behavior, we automatically prepend ./ to the selected path if
+        # begins with a dot or slash. If the path is a directory, Fish will cd into it. If the path is
+        # an executable, Fish will execute it. To help users harness this convenient behavior, we
+        # automatically prepend ./ to the selected path if
         # - only one path was selected,
         # - the user was in the middle of inputting the first token,
-        # - and the path doesn't already begin with a dot, slash, or tilde
+        # - and the path doesn't already begin with a dot or slash
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
-        if test (count $file_paths_selected) = 1 && not string match --regex "^[.|/|~]" $file_paths_selected
+        if test (count $file_paths_selected) = 1 && not string match --regex "^[.|/]" $file_paths_selected
             set commandline_tokens (commandline --tokenize)
             if test "$commandline_tokens" = "$current_token"
                 set file_paths_selected ./$file_paths_selected

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -15,7 +15,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
         set --append fd_arguments --base-directory=$expanded_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --append fzf_arguments --prompt=$token --preview="__fzf_preview_file $token{}"
-        set file_paths_selected $expanded_token(fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
+        set file_paths_selected $token(fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
     else
         set --append fzf_arguments --query=$token --preview='__fzf_preview_file {}'
         set file_paths_selected (fd $fd_arguments 2>/dev/null | fzf $fzf_arguments)
@@ -29,12 +29,10 @@ function __fzf_search_current_dir --description "Search the current directory. R
         # - if the path is a directory, the user can hit Enter one more time to immediately cd into it (fish will
         #   attempt to cd implicitly if a directory name starts with a dot)
         if test (count $file_paths_selected) = 1
-            if string match --invert "^/" $file_path_selected[1]
-                set commandline_tokens (commandline --tokenize)
-                set current_token (commandline --current-token)
-                if test "$commandline_tokens" = "$current_token"
-                    set file_paths_selected ./$file_paths_selected
-                end
+            set commandline_tokens (commandline --tokenize)
+            set current_token (commandline --current-token)
+            if test "$commandline_tokens" = "$current_token"
+                set file_paths_selected ./$file_paths_selected
             end
         end
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -32,7 +32,8 @@ function __fzf_search_current_dir --description "Search the current directory. R
         # - the user was in the middle of inputting the first token,
         # - and the path doesn't already begin with a dot or slash
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
-        if test (count $file_paths_selected) = 1 && not string match --regex "^[.|/]" $file_paths_selected
+        if test (count $file_paths_selected) = 1 \
+                && not string match --quiet --regex "^[.|/]" $file_paths_selected
             set commandline_tokens (commandline --tokenize)
             if test "$commandline_tokens" = "$current_token"
                 set file_paths_selected ./$file_paths_selected

--- a/tests/search_current_dir/no_dot_slash_if_unneeded.fish
+++ b/tests/search_current_dir/no_dot_slash_if_unneeded.fish
@@ -1,6 +1,9 @@
+# set everything up so that a path starting with / is outputted by fzf
 mock commandline \* ""
 mock commandline "--current-token --replace --" "echo \$argv"
 mock fd \* ""
 mock fzf \* "echo /Users/patrickf"
+
+# since there is already a /, no ./ should be prepended
 set result (__fzf_search_current_dir)
 @test "doesn't prepend ./ if path already starts with /" $result = "/Users/patrickf"

--- a/tests/search_current_dir/no_dot_slash_if_unneeded.fish
+++ b/tests/search_current_dir/no_dot_slash_if_unneeded.fish
@@ -1,7 +1,6 @@
-mock commandline --current-token "echo /Users/"
-mock commandline "--current-token --replace --" "echo \$argv"
 mock commandline \* ""
-mock fd \* "echo patrickf/"
-set --export --append FZF_DEFAULT_OPTS "--select-1"
+mock commandline "--current-token --replace --" "echo \$argv"
+mock fd \* ""
+mock fzf \* "echo /Users/patrickf"
 set result (__fzf_search_current_dir)
-@test "doesn't prepend ./ if path already starts with /" $result = "/Users/patrickf/"
+@test "doesn't prepend ./ if path already starts with /" $result = "/Users/patrickf"

--- a/tests/search_current_dir/no_dot_slash_if_unneeded.fish
+++ b/tests/search_current_dir/no_dot_slash_if_unneeded.fish
@@ -1,0 +1,7 @@
+mock commandline --current-token "echo /Users/"
+mock commandline "--current-token --replace --" "echo \$argv"
+mock commandline \* ""
+mock fd \* "echo patrickf/"
+set --export --append FZF_DEFAULT_OPTS "--select-1"
+set result (__fzf_search_current_dir)
+@test "doesn't prepend ./ if path already starts with /" $result = "/Users/patrickf/"


### PR DESCRIPTION
If the file path already starts with . or /, which can happen if such a path was used as the base directory, then don't prepend ./.
Without such logic, the path becomes invalid. For example:
- if the current token is `/etc/` and you select `systemd`,  you end up with `'.//etc/systemd'`
- if the current token is `~/` and you select `Desktop`, you end up with `'./~/desktop'`

Additionally, since the output paths are quoted, we need to use the expanded token when outputting paths because ~ doesn't get expanded inside quotes.