### PR TITLE
Make preview directory command configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Need help? These Wiki pages can guide you:
 [bat]: https://github.com/sharkdp/bat
 [brew]: https://brew.sh
 [build status badge]: https://img.shields.io/github/workflow/status/patrickf1/fzf.fish/CI
-[custom preview command]: functions/__fzf_preview_file.fish
+[custom preview command]: functions/__fzf_preview_file.fish#L7
 [cd docs]: https://fishshell.com/docs/current/cmds/cd.html
 [command history search]: images/command_history.gif
 [conf.d/fzf.fish]: conf.d/fzf.fish

--- a/README.md
+++ b/README.md
@@ -118,12 +118,13 @@ set --export FZF_DEFAULT_OPTS --height 50% --margin 1
 ```
 
 ### Changing the command used to preview folders
-The search files feature, by default, uses `ls -A -F` to preview the contents of a directory. Users may change the command used by setting the `fzf_preview_dir_cmd` variable. For example, in your `config.fish`, you may put:
+The search files feature, by default, uses `ls -A -F` to preview the contents of a directory. To integrate with the variety of `ls` replacements available, the command used to preview directories is configurable through the `fzf_preview_dir_cmd` variable. For example, in your `config.fish`, you may put:
 
 ```fish
 set fzf_preview_dir_cmd exa --all --color=always
 ```
-Do not specify a target path in the preview command, because `fzf.fish` will [provide the path for you][custom preview command].
+
+Do not specify a target path in the command, as `fzf.fish` will [prepend the directory][custom preview command] to preview to the command itself.
 
 ### Change the key binding or Fzf options for a single command
 See the [FAQ][] Wiki page.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,12 @@ set --export FZF_DEFAULT_OPTS --height 50% --margin 1
 ```
 
 ### Changing the command used to preview folders
-TODO
+The search files feature, by default, uses `ls -A -F` to preview the contents of a directory. Users may change the command used by setting the `fzf_preview_dir_cmd` variable. For example, in your `config.fish`, you may put:
+
+```fish
+set fzf_preview_dir_cmd exa --all --color=always
+```
+Do not specify a target path in the preview command, because `fzf.fish` will [provide the path for you][custom preview command].
 
 ### Change the key binding or Fzf options for a single command
 See the [FAQ][] Wiki page.
@@ -139,6 +144,7 @@ Need help? These Wiki pages can guide you:
 [bat]: https://github.com/sharkdp/bat
 [brew]: https://brew.sh
 [build status badge]: https://img.shields.io/github/workflow/status/patrickf1/fzf.fish/CI
+[custom preview command]: functions/__fzf_preview_file.fish
 [cd docs]: https://fishshell.com/docs/current/cmds/cd.html
 [command history search]: images/command_history.gif
 [conf.d/fzf.fish]: conf.d/fzf.fish

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Alternatively, you can override it in your `config.fish`:
 set --export FZF_DEFAULT_OPTS --height 50% --margin 1
 ```
 
+### Changing the command used to preview folders
+TODO
+
 ### Change the key binding or Fzf options for a single command
 See the [FAQ][] Wiki page.
 

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -3,8 +3,13 @@ function __fzf_preview_file --argument-names file_path --description "Print a pr
     if test -f "$file_path" # regular file
         bat --style=numbers --color=always "$file_path"
     else if test -d "$file_path" # directory
-        set --local CLICOLOR_FORCE true
-        command ls -A "$file_path" # list hidden files as well, except for . and ..
+        if set --query fzf_preview_dir_cmd
+            eval $fzf_preview_dir_cmd
+        else
+            # -A list hidden files as well, except for . and ..
+            # -F helps classify files by appending symbols after the file name
+            command ls -A -F "$file_path"
+        end
     else if test -L "$file_path" # symlink
         # notify user and recurse on the target of the symlink, which can be any of these file types
         set -l target_path (realpath $file_path)

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -4,7 +4,7 @@ function __fzf_preview_file --argument-names file_path --description "Print a pr
         bat --style=numbers --color=always "$file_path"
     else if test -d "$file_path" # directory
         if set --query fzf_preview_dir_cmd
-            eval $fzf_preview_dir_cmd
+            eval $fzf_preview_dir_cmd "$file_path"
         else
             # -A list hidden files as well, except for . and ..
             # -F helps classify files by appending symbols after the file name

--- a/tests/preview_file/custom_dir_preview.fish
+++ b/tests/preview_file/custom_dir_preview.fish
@@ -1,0 +1,4 @@
+set fzf_preview_dir_cmd exa
+mock exa . "echo file.txt"
+set actual (__fzf_preview_file .)
+@test "correctly uses custom command to preview directories" $actual = file.txt


### PR DESCRIPTION
To acquiesce to the popularity and diversity of ls alternatives (e.g. https://github.com/ogham/exa, https://github.com/Peltoche/lsd, https://github.com/athityakumar/colorls, tree, all of which have many different options to configure them), I have finally decided to make the command used to preview directories configurable. Users can place their desired command in fzf_preview_dir_cmd and fzf.fish will use it.

Related to #117 and #101