### PR TITLE
Show command preview in history search

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 
 - **Search input:** the command history from all interactive sessions of Fish
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>R</kbd> (`R` for reverse-i-search)
-- **Preview window:** the untruncated command
+- **Preview window:** the entire command, wrapped
 
 ### A shell variable
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 
 - **Search input:** the command history from all interactive sessions of Fish
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>R</kbd> (`R` for reverse-i-search)
-- **Preview window:** the current command fully displayed or in a pager
+- **Preview window:** the untruncated command
 
 ### A shell variable
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 
 - **Search input:** the command history from all interactive sessions of Fish
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>R</kbd> (`R` for reverse-i-search)
+- **Preview window:** the current command fully displayed or in a pager
 
 ### A shell variable
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -7,7 +7,7 @@ function __fzf_search_history --description "Search command history. Replace the
         fzf --read0 --tiebreak=index --query=(commandline) \
             # preview the current command in a window at the bottom 3 lines tall
             --preview="echo {4..}" \
-            --preview-window="bottom:3" |
+            --preview-window="bottom:3:wrap" |
         string collect
     )
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -4,7 +4,9 @@ function __fzf_search_history --description "Search command history. Replace the
     set command_with_ts (
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S | " |
-        fzf --read0 --tiebreak=index --query=(commandline) |
+        fzf --read0 --tiebreak=index --query=(commandline) \
+            --preview="echo {4..}" \
+            --preview-window="bottom:20%" |
         string collect
     )
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -5,8 +5,9 @@ function __fzf_search_history --description "Search command history. Replace the
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S | " |
         fzf --read0 --tiebreak=index --query=(commandline) \
+            # preview the current command in a window at the bottom 3 lines tall
             --preview="echo {4..}" \
-            --preview-window="bottom:20%" |
+            --preview-window="bottom:3" |
         string collect
     )
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -5,7 +5,7 @@ function __fzf_search_history --description "Search command history. Replace the
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S | " |
         fzf --read0 --tiebreak=index --query=(commandline) \
-            # preview the current command in a window at the bottom 3 lines tall
+            # preview current command in a window at the bottom 3 lines tall
             --preview="echo {4..}" \
             --preview-window="bottom:3:wrap" |
         string collect


### PR DESCRIPTION
Long commands get truncated in the fzf finder, while the spacing of multi-line commands are messed up. To remedy this,
show a preview of the entire command at the bottom.