### PR TITLE
Check Fish syntax and format in CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -32,6 +32,26 @@ jobs:
         run: fishtape tests/*/*
         shell: fish {0}
 
+  syntax-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: fish-actions/install-fish@v1
+
+      - uses: fish-actions/syntax-check@v1
+
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: fish-actions/install-fish@v1
+
+      - uses: fish-actions/format-check@v1
+
   prettier:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -41,7 +41,8 @@ jobs:
       - uses: fish-actions/install-fish@v1
 
       - uses: fish-actions/syntax-check@v1
-
+  
+  # check Fish format
   format-check:
     runs-on: ubuntu-latest
 
@@ -51,7 +52,8 @@ jobs:
       - uses: fish-actions/install-fish@v1
 
       - uses: fish-actions/format-check@v1
-
+  
+  # check Markdown and Yaml format
   prettier:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: fish-actions/install-fish@v1
 
       - uses: fish-actions/syntax-check@v1
-  
+
   # check Fish format
   format-check:
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
       - uses: fish-actions/install-fish@v1
 
       - uses: fish-actions/format-check@v1
-  
+
   # check Markdown and Yaml format
   prettier:
     runs-on: ubuntu-latest

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -7,20 +7,20 @@ set --global fzf_search_vars_cmd '__fzf_search_shell_variables (set --show | psu
 # Set up the default, mnemonic key bindings unless the user has chosen to customize them
 if not set --query fzf_fish_custom_keybindings
     # \cf is Ctrl+f
-    bind \cf '__fzf_search_current_dir'
-    bind \cr '__fzf_search_history'
+    bind \cf __fzf_search_current_dir
+    bind \cr __fzf_search_history
     bind \cv $fzf_search_vars_cmd
     # The following two key binding use Alt as an additional modifier key to avoid conflicts
-    bind \e\cl '__fzf_search_git_log'
-    bind \e\cs '__fzf_search_git_status'
+    bind \e\cl __fzf_search_git_log
+    bind \e\cs __fzf_search_git_status
 
     # set up the same key bindings for insert mode if using fish_vi_key_bindings
-    if test "$fish_key_bindings" = 'fish_vi_key_bindings'
-        bind --mode insert \cf '__fzf_search_current_dir'
-        bind --mode insert \cr '__fzf_search_history'
+    if test "$fish_key_bindings" = fish_vi_key_bindings
+        bind --mode insert \cf __fzf_search_current_dir
+        bind --mode insert \cr __fzf_search_history
         bind --mode insert \cv $fzf_search_vars_cmd
-        bind --mode insert \e\cl '__fzf_search_git_log'
-        bind --mode insert \e\cs '__fzf_search_git_status'
+        bind --mode insert \e\cl __fzf_search_git_log
+        bind --mode insert \e\cs __fzf_search_git_status
     end
 end
 

--- a/functions/__fzf_extract_var_info.fish
+++ b/functions/__fzf_extract_var_info.fish
@@ -6,17 +6,17 @@ function __fzf_extract_var_info --argument-names variable_name set_show_output -
     # $variable_name[
     string match --entire --regex "^\\\$$variable_name(?:: set|\[)" <$set_show_output |
 
-    # Strip the variable name from the scope info, replacing...
-    # $variable_name: set in global scope
-    # ...with...
-    # set in global scope
-    string replace --regex "^\\\$$variable_name: " '' |
+        # Strip the variable name from the scope info, replacing...
+        # $variable_name: set in global scope
+        # ...with...
+        # set in global scope
+        string replace --regex "^\\\$$variable_name: " '' |
 
-    # From the lines of values, keep only the index and value, replacing...
-    # $variable_name[1]: length=14 value=|variable_value|
-    # ...with...
-    # [1] variable_value
-    string replace --regex "^\\\$$variable_name(\[\d+\]).+?\|(.+)\|\$" '\$1 \$2'
+        # From the lines of values, keep only the index and value, replacing...
+        # $variable_name[1]: length=14 value=|variable_value|
+        # ...with...
+        # [1] variable_value
+        string replace --regex "^\\\$$variable_name(\[\d+\]).+?\|(.+)\|\$" '\$1 \$2'
 
     # Final output example for $PATH:
     # set in global scope, unexported, with 5 elements

--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -24,7 +24,7 @@ function __fzf_preview_file --argument-names file_path --description "Print a pr
     else if test -b "$file_path"
         __fzf_report_file_type "$file_path" "block device file"
     else if test -S "$file_path"
-        __fzf_report_file_type "$file_path" "socket"
+        __fzf_report_file_type "$file_path" socket
     else if test -p "$file_path"
         __fzf_report_file_type "$file_path" "named pipe"
     else

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -13,7 +13,7 @@ function __fzf_search_git_status --description "Search the output of git status.
             set cleaned_paths
 
             for path in $selected_paths
-                if test (string sub --length 1 $path) = 'R'
+                if test (string sub --length 1 $path) = R
                     # path has been renamed and looks like "R LICENSE -> LICENSE.md"
                     # extract the path to use from after the arrow
                     set --append cleaned_paths (string split -- "-> " $path)[-1]

--- a/tests/search_current_dir/no_dot_slash_if_unneeded.fish
+++ b/tests/search_current_dir/no_dot_slash_if_unneeded.fish
@@ -6,4 +6,4 @@ mock fzf \* "echo /Users/patrickf"
 
 # since there is already a /, no ./ should be prepended
 set result (__fzf_search_current_dir)
-@test "doesn't prepend ./ if path already starts with /" "$result" = "/Users/patrickf"
+@test "doesn't prepend ./ if path already starts with /" "$result" = /Users/patrickf

--- a/tests/search_git_log/outputs_right_commit.fish
+++ b/tests/search_git_log/outputs_right_commit.fish
@@ -4,14 +4,14 @@ mock commandline \* ""
 if git cat-file -e c6326dbda6b1f48ecbd015838073213be3bf6ec1 2>/dev/null # sha is a random commit that CI wouldn't pull
     # This test is running locally.
     set --export --append FZF_DEFAULT_OPTS "--filter='Refactor: one folder per test suite, one file per test case'"
-    set expected "6c558feee95c34ce82ded8e08d98f5f73d0f9b97"
+    set expected 6c558feee95c34ce82ded8e08d98f5f73d0f9b97
     set actual (__fzf_search_git_log)
     @test "outputs right commit (local)" "$actual" = "$expected"
 else
     # This test is running on CI. Since we don't want to have CI download the entire git log just
     # for a few tests, we will just test if it is able to output the sha of the only commit available
     # by forcing fzf to select only commit available and checking if the ouputted sha exists
-    set --export --append FZF_DEFAULT_OPTS "--select-1"
+    set --export --append FZF_DEFAULT_OPTS --select-1
     git cat-file -e (__fzf_search_git_log) 2>/dev/null
     @test "outputs a valid git sha (CI)" $status -eq 0
 end


### PR DESCRIPTION
I recently created two new github actions for Fish, [format-check](https://github.com/fish-actions/format-check), and [syntax-check](https://github.com/fish-actions/syntax-check). This PR adds them to the CI workflow. I also ran Fish 3.2's new `fish_indent` on the codebase so that `format-check` would be happy.