### PR TITLE
[Search files] prevent token from being interpreted as an argument

### DIFF
--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -6,7 +6,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
     set fd_opts --color=always $fzf_fd_opts
     set fzf_arguments --multi --ansi
     set current_token (commandline --current-token)
-    set token (string unescape $current_token)
+    set token (string unescape -- $current_token)
     # need to expand ~ in the directory name since fd can't expand it
     set expanded_token (string replace --regex -- "^~/" $HOME/ $token)
 


### PR DESCRIPTION
Just like #80, solves an issue introduced in https://github.com/PatrickF1/fzf.fish/pull/119/files#diff-fd01aaa375d8928720283f620b157dd451536fe8ef06d837110f2502b2f1660eR9.