### PR TITLE
[Search history] preview commands with fish_indent --ansi instead of bat

### DIFF
--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -2,7 +2,7 @@ function __fzf_search_history --description "Search command history. Replace the
     # history merge incorporates history changes from other fish sessions
     builtin history merge
 
-    # Make sure that fzf uses fish to execute __fzf_preview_file.
+    # Make sure that fzf uses fish so we can run fish_indent.
     # See similar comment in __fzf_search_shell_variables.fish.
     set --local --export SHELL (command --search fish)
 

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -1,12 +1,17 @@
 function __fzf_search_history --description "Search command history. Replace the command line with the selected command."
     # history merge incorporates history changes from other fish sessions
     builtin history merge
+
+    # Make sure that fzf uses fish to execute __fzf_preview_file.
+    # See similar comment in __fzf_search_shell_variables.fish.
+    set --local --export SHELL (command --search fish)
+
     set command_with_ts (
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S | " |
         fzf --read0 --tiebreak=index --query=(commandline) \
             # preview current command in a window at the bottom 3 lines tall
-            --preview="echo -- {4..} | bat --plain --color=always --language=fish" \
+            --preview="echo -- {4..} | fish_indent --ansi" \
             --preview-window="bottom:3:wrap" |
         string collect
     )


### PR DESCRIPTION
I happened to be visiting this repository, and I found a use for the trick I learned a little bit ago! Great idea @kidonng.

Sidenote, at this point I would argue for doing
```fish
# Make sure that fzf uses fish to execute __fzf_preview_file.
# See similar comment in __fzf_search_shell_variables.fish.
set --local --export SHELL (command --search fish)
```
in every command by default somehow. We're already doing it in the majority.