### PR TITLE
Add git diff preview to Modified paths function

### DIFF
--- a/functions/__fzf_git_diff.fish
+++ b/functions/__fzf_git_diff.fish
@@ -1,5 +1,5 @@
 function __fzf_git_diff --argument-names file_status file_path --description "Print git diff for the given file based on its status."
-    if test $file_status = "A" || test $file_status = "??"
+    if test $file_status = A || test $file_status = "??"
         git diff --color=always --no-index -- /dev/null $file_path
     else
         git diff --color=always -- $file_path

--- a/functions/__fzf_git_diff.fish
+++ b/functions/__fzf_git_diff.fish
@@ -1,0 +1,7 @@
+function __fzf_git_diff --argument-names file_status file_path --description "Print git diff for the given file based on its status."
+    if test $file_status = "A" || test $file_status = "??"
+        git diff --color=always --no-index -- /dev/null $file_path
+    else
+        git diff --color=always -- $file_path
+    end
+end

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -5,7 +5,7 @@ function __fzf_search_git_status --description "Search the output of git status.
         set selected_paths (
             # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
             git -c color.status=always status --short |
-            fzf --ansi --multi --query=(commandline --current-token)
+            fzf --ansi --multi --query=(commandline --current-token) --preview '__fzf_git_diff {1} {2}'
         )
         if test $status -eq 0
             # git status --short automatically escapes the paths of most files for us so not going to bother trying to handle


### PR DESCRIPTION
Inspired by [forgit](https://github.com/wfxr/forgit):

![image](https://user-images.githubusercontent.com/44045911/111496037-e4d73100-877a-11eb-8b4a-63bd8fc03e69.png)

In fact this is the only function without a preview window now.