### PR TITLE
Allow passing custom fzf opts to individual commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,12 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 | Search command history | `fzf_history_opts`    |
 | Search shell variables | `fzf_shell_vars_opts` |
 
-This is very useful for setting up key bindings to greatly improve the usefulness of these features. Note that fzf does not allow overriding options; it will always use whichever option appears first.
+These variables are appended last to fzf's argument list. Because fzf will use whichever option appears last when options conflict, your custom options will override any options preset by `fzf.fish`. This empowers you to greatly customize and augment the existing features of `fzf.fish`. Some possibilities:
+
+- override the preview command
+- set up your own key binding to do things like open file in Vim
+- re-populate fzf's input list on change
+- change the search mode
 
 ### Change the command used to preview folders
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 
 ![shell variables search][]
 
-- **Search input:** all the variable names of the environment, both local and exported
+- **Search input:** all the variable names of the environment currently [in scope][var scope]
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>V</kbd> (`V` for variable)
 - **Preview window:** the scope info and values of the variable
 - **Remarks**
@@ -90,7 +90,7 @@ On certain distribution of Linux, you will need to alias `fdfind` to `fd` (see [
 
 ## Configuration
 
-### Custom key bindings
+### Customize the key bindings
 
 If you would like to customize the key bindings, first, prevent the default key bindings from executing by setting `fzf_fish_custom_keybindings` as an [universal variable][]. You can do this with
 
@@ -102,21 +102,19 @@ Do not try to set `fzf_fish_custom_keybindings` in your `config.fish` because th
 
 Next, set your own key bindings by following [conf.d/fzf.fish][] as an example.
 
-### Fzf default options
+### Pass fzf options to all commands
 
 fzf supports setting default options via the [FZF_DEFAULT_OPTS][] environment variable. If it is set, fzf will implicitly prepend its value to the options passed in on every execution, scripted or interactive.
 
-To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish][] for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set your own `FZF_DEFAULT_OPTS` universal variable. For example:
-
-```fish
-set --universal --export FZF_DEFAULT_OPTS --height 50% --margin 1
-```
-
-Alternatively, you can override it in your `config.fish`:
+To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish][] for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set export your own `FZF_DEFAULT_OPTS` variable. For example:
 
 ```fish
 set --export FZF_DEFAULT_OPTS --height 50% --margin 1
 ```
+
+### Pass fzf options to a specific command
+
+`fzf.fish` allows passing custom options to the invocation of fzf by command through variables.
 
 ### Change the command used to preview folders
 
@@ -136,7 +134,7 @@ To pass custom options to `fd` when it is executed to populate the list of files
 set fzf_fd_opts --hidden --exclude=.git
 ```
 
-### Change the key binding or Fzf options for a single command
+### Change the key binding for a single command
 
 See the [FAQ][] Wiki page.
 
@@ -180,3 +178,4 @@ Need help? These Wiki pages can guide you:
 [troubleshooting]: https://github.com/PatrickF1/fzf.fish/wiki/Troubleshooting
 [universal variable]: https://fishshell.com/docs/current/#more-on-universal-variables
 [unix philosophy]: https://en.wikipedia.org/wiki/Unix_philosophy
+[var scope]: https://fishshell.com/docs/current/#variable-scope

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 
 These variables are appended last to fzf's argument list. Because fzf will use whichever option appears last when options conflict, your custom options can override any options preset by `fzf.fish`. This empowers you to greatly customize and augment the existing features. Some possibilities:
 
-- set up key binding to do take action on the selected line to do things like
-  - [toggle preview window](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d)
+- set up [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) to take action on the selected line:
   - [open file in Vim](https://github.com/junegunn/fzf/issues/1360)
   - [preview image files](https://gitter.im/junegunn/fzf?at=5947962ef6a78eab48620792)
+  - [copy to clipboard](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d)
   - git checkout commit
   - git reset file
 - override the preview command

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ These variables are appended last to fzf's argument list. Because fzf will use t
 
 ### Change the command used to preview folders
 
-The search files feature, by default, uses `ls` to preview the contents of a directory. To integrate with the variety of `ls` replacements available, the command used to preview directories is configurable through the `fzf_preview_dir_cmd` variable. For example, in your `config.fish`, you may put:
+The search directory feature, by default, uses `ls` to preview the contents of a directory. To integrate with the variety of `ls` replacements available, the command used to preview directories is configurable through the `fzf_preview_dir_cmd` variable. For example, in your `config.fish`, you may put:
 
 ```fish
 set fzf_preview_dir_cmd exa --all --color=always

--- a/README.md
+++ b/README.md
@@ -109,12 +109,22 @@ fzf supports setting default options via the [FZF_DEFAULT_OPTS][] environment va
 To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish][] for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set export your own `FZF_DEFAULT_OPTS` variable. For example:
 
 ```fish
-set --export FZF_DEFAULT_OPTS --height 50% --margin 1
+set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 ```
 
 ### Pass fzf options to a specific command
 
-`fzf.fish` allows passing custom options to the invocation of fzf by command through variables.
+`fzf.fish` allows passing custom options to fzf in each function individually through these variables:
+
+| Feature                | Variable              |
+| ---------------------- | --------------------- |
+| Search directory       | `fzf_dir_opts`        |
+| Search git status      | `fzf_git_status_opts` |
+| Search git log         | `fzf_git_log_opts`    |
+| Search command history | `fzf_history_opts`    |
+| Search shell variables | `fzf_shell_vars_opts` |
+
+This is very useful for setting up key bindings to greatly improve the usefulness of these features. Note that fzf does not allow overriding options; it will always use whichever option appears first.
 
 ### Change the command used to preview folders
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 
 ### Pass fzf options to a specific command
 
-Custom options can be passed to fzf for each feature individually through these variables:
+The following variables can store custom options that will be passed to fzf by their respective feature:
 
 | Feature                | Variable              |
 | ---------------------- | --------------------- |
@@ -124,7 +124,7 @@ Custom options can be passed to fzf for each feature individually through these 
 | Search command history | `fzf_history_opts`    |
 | Search shell variables | `fzf_shell_vars_opts` |
 
-These variables are appended last to fzf's argument list. Because fzf will use the option appearing last when options conflict, your custom options can override preset options. This unlocks a variety of possibilities in customizing and augmenting each feature such as:
+They are always appended last to fzf's argument list. Because fzf uses the option appearing last when options conflict, your custom options can override hardcoded options. Custom fzf options unlocks a variety of possibilities in customizing and augmenting each feature such as:
 
 - add [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) within fzf to operate on the selected line:
   - [open file in Vim](https://github.com/junegunn/fzf/issues/1360)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Next, set your own key bindings by following [conf.d/fzf.fish][] as an example.
 
 ### Pass fzf options to all commands
 
-fzf supports setting default options via the [FZF_DEFAULT_OPTS][] environment variable. If it is set, fzf will implicitly prepend its value to the options passed in on every execution, scripted or interactive.
+fzf supports setting default options via the [FZF_DEFAULT_OPTS][] environment variable. If it is set, fzf will implicitly prepend it to the options passed in on every execution, scripted or interactive.
 
 To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish][] for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set export your own `FZF_DEFAULT_OPTS` variable. For example:
 
@@ -114,7 +114,7 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 
 ### Pass fzf options to a specific command
 
-`fzf.fish` allows passing custom options to fzf in each function individually through these variables:
+`fzf.fish` allows passing additional options to fzf in each feature individually through these variables:
 
 | Feature                | Variable              |
 | ---------------------- | --------------------- |
@@ -148,7 +148,7 @@ Do not specify a target path in the command, as `fzf.fish` will [prepend the dir
 
 ### Change the files searched
 
-To pass custom options to `fd` when it is executed to populate the list of files for the search files feature, set the `fzf_fd_opts` variable. For example, to include hidden files but not `.git`, put this in your `config.fish`:
+To pass custom options to `fd` when it is executed to populate the list of files for the search directory feature, set the `fzf_fd_opts` variable. For example, to include hidden files but not `.git`, put this in your `config.fish`:
 
 ```fish
 set fzf_fd_opts --hidden --exclude=.git

--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ Custom options can be passed to fzf for each feature individually through these 
 
 These variables are appended last to fzf's argument list. Because fzf will use the option appearing last when options conflict, your custom options can override preset options. This unlocks a variety of possibilities in customizing and augmenting each feature such as:
 
-- add [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) within fzf to take action on the selected line:
+- add [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) within fzf to operate on the selected line:
   - [open file in Vim](https://github.com/junegunn/fzf/issues/1360)
   - [preview image files](https://gitter.im/junegunn/fzf?at=5947962ef6a78eab48620792)
   - [copy to clipboard](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d)
   - git checkout commit
   - git reset file
 - adjust the preview command or window
-- [re-populate fzf's input list on change](https://github.com/junegunn/fzf/issues/1750)
+- [re-populate fzf's input list on demand](https://github.com/junegunn/fzf/issues/1750)
 - change the search mode
 
 ### Change the command used to preview folders

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 These variables are appended last to fzf's argument list. Because fzf will use whichever option appears last when options conflict, your custom options can override any options preset by `fzf.fish`. This empowers you to greatly customize and augment the existing features. Some possibilities:
 
 - set up key binding to do take action on the selected line to do things like
+  - [toggle preview window](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d)
   - [open file in Vim](https://github.com/junegunn/fzf/issues/1360)
-  - [copy selection to clipboard](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d)
+  - [preview image files](https://gitter.im/junegunn/fzf?at=5947962ef6a78eab48620792)
   - git checkout commit
   - git reset file
 - override the preview command

--- a/README.md
+++ b/README.md
@@ -124,11 +124,15 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 | Search command history | `fzf_history_opts`    |
 | Search shell variables | `fzf_shell_vars_opts` |
 
-These variables are appended last to fzf's argument list. Because fzf will use whichever option appears last when options conflict, your custom options will override any options preset by `fzf.fish`. This empowers you to greatly customize and augment the existing features of `fzf.fish`. Some possibilities:
+These variables are appended last to fzf's argument list. Because fzf will use whichever option appears last when options conflict, your custom options can override any options preset by `fzf.fish`. This empowers you to greatly customize and augment the existing features. Some possibilities:
 
+- set up key binding to do take action on the selected line to do things like
+  - [open file in Vim](https://github.com/junegunn/fzf/issues/1360)
+  - [copy selection to clipboard](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d)
+  - git checkout commit
+  - git reset file
 - override the preview command
-- set up your own key binding to do things like open file in Vim
-- re-populate fzf's input list on change
+- [re-populate fzf's input list on change](https://github.com/junegunn/fzf/issues/1750)
 - change the search mode
 
 ### Change the command used to preview folders

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 
 ### Pass fzf options to a specific command
 
-`fzf.fish` allows passing additional options to fzf in each feature individually through these variables:
+Custom options can be passed to fzf for each feature individually through these variables:
 
 | Feature                | Variable              |
 | ---------------------- | --------------------- |
@@ -124,15 +124,15 @@ set --export FZF_DEFAULT_OPTS --height 50% --no-extended +i
 | Search command history | `fzf_history_opts`    |
 | Search shell variables | `fzf_shell_vars_opts` |
 
-These variables are appended last to fzf's argument list. Because fzf will use whichever option appears last when options conflict, your custom options can override any options preset by `fzf.fish`. This empowers you to greatly customize and augment the existing features. Some possibilities:
+These variables are appended last to fzf's argument list. Because fzf will use the option appearing last when options conflict, your custom options can override preset options. This unlocks a variety of possibilities in customizing and augmenting each feature such as:
 
-- set up [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) to take action on the selected line:
+- add [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) within fzf to take action on the selected line:
   - [open file in Vim](https://github.com/junegunn/fzf/issues/1360)
   - [preview image files](https://gitter.im/junegunn/fzf?at=5947962ef6a78eab48620792)
   - [copy to clipboard](https://betterprogramming.pub/boost-your-command-line-productivity-with-fuzzy-finder-985aa162ba5d)
   - git checkout commit
   - git reset file
-- override the preview command
+- adjust the preview command or window
 - [re-populate fzf's input list on change](https://github.com/junegunn/fzf/issues/1750)
 - change the search mode
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -16,10 +16,10 @@ function __fzf_search_current_dir --description "Search the current directory. R
     if string match --quiet -- "*/" $token && test -d "$unescaped_exp_token"
         set --append fd_opts --base-directory=$unescaped_exp_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
-        set --append fzf_arguments --prompt="$unescaped_exp_token" --preview="__fzf_preview_file $expanded_token{}"
+        set --prepend fzf_arguments --prompt="$unescaped_exp_token" --preview="__fzf_preview_file $expanded_token{}"
         set file_paths_selected $unescaped_exp_token(fd $fd_opts 2>/dev/null | fzf $fzf_arguments)
     else
-        set --append fzf_arguments --query="$unescaped_exp_token" --preview='__fzf_preview_file {}'
+        set --prepend fzf_arguments --query="$unescaped_exp_token" --preview='__fzf_preview_file {}'
         set file_paths_selected (fd $fd_opts 2>/dev/null | fzf $fzf_arguments)
     end
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -4,7 +4,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
     set --local --export SHELL (command --search fish)
 
     set fd_opts --color=always $fzf_fd_opts
-    set fzf_arguments --multi --ansi
+    set fzf_arguments --multi --ansi $fzf_dir_opts
     set token (commandline --current-token)
     # expand ~ in the directory name since fd can't expand it
     set expanded_token (string replace --regex -- "^~/" $HOME/ $token)

--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -11,9 +11,11 @@ function __fzf_search_git_log --description "Search the output of git log and pr
             # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
             # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
             git log --color=always --format=format:$log_fmt_str | \
-            fzf --ansi --tiebreak=index \
+            fzf --ansi \
+                --tiebreak=index \
                 --preview='git show --color=always {1}' \
-                --query=(commandline --current-token)
+                --query=(commandline --current-token) \
+                $fzf_git_log_opts
         )
         if test $status -eq 0
             set abbreviated_commit_hash (string split --max 1 " " $selected_log_line)[1]

--- a/functions/__fzf_search_git_status.fish
+++ b/functions/__fzf_search_git_status.fish
@@ -5,7 +5,10 @@ function __fzf_search_git_status --description "Search the output of git status.
         set selected_paths (
             # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
             git -c color.status=always status --short |
-            fzf --ansi --multi --query=(commandline --current-token)
+            fzf --ansi \
+                --multi \
+                --query=(commandline --current-token) \
+                $fzf_git_status_opts
         )
         if test $status -eq 0
             # git status --short automatically escapes the paths of most files for us so not going to bother trying to handle

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -10,7 +10,6 @@ function __fzf_search_history --description "Search command history. Replace the
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S | " |
         fzf --read0 \
-            # keep commands in order of time executed
             --tiebreak=index \
             --query=(commandline) \
             # preview current command using fish_ident in a window at the bottom 3 lines tall

--- a/functions/__fzf_search_history.fish
+++ b/functions/__fzf_search_history.fish
@@ -9,10 +9,14 @@ function __fzf_search_history --description "Search command history. Replace the
     set command_with_ts (
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S | " |
-        fzf --read0 --tiebreak=index --query=(commandline) \
-            # preview current command in a window at the bottom 3 lines tall
+        fzf --read0 \
+            # keep commands in order of time executed
+            --tiebreak=index \
+            --query=(commandline) \
+            # preview current command using fish_ident in a window at the bottom 3 lines tall
             --preview="echo -- {4..} | fish_indent --ansi" \
-            --preview-window="bottom:3:wrap" |
+            --preview-window="bottom:3:wrap" \
+            $fzf_history_opts |
         string collect
     )
 

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -32,7 +32,8 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     set variable_name (
         printf '%s\n' $all_variable_names |
         fzf --preview "__fzf_extract_var_info {} $set_show_output" \
-            --query=$cleaned_curr_token
+            --query=$cleaned_curr_token \
+            $fzf_shell_vars_opts
     )
 
     if test $status -eq 0


### PR DESCRIPTION
The following variables can store the custom fzf options that will be passed to fzf by their respective feature:
  fzf_dir_opts => search directory
  fzf_git_status_opts => search git status
  fzf_git_log_opts => search git log
  fzf_history_opts => search history
  fzf_shell_vars_opts => search shell variables

They are always appended last to fzf's argument list so that they can override any fzf options that are hardcoded in by fzf.fish. This might lead to some users shooting themselves in the foot but also unlocks numerous opportunities for the user to customize or augment the existing features. 

This was an oft requested feature that I parried for a long time but now I am very excited to finally add. With this, change, some of the cool ideas now made possible include 
- add key bindings within fzf to operate on the selected line, e.g. open file in vim, preview file as image, copy to clipboard, git checkout commit, git reset commit
- adjust the preview window or command
- re-populate fzf's input list on demand
- change the search mode
- and many, many more