### PR TITLE
Use Homebrew to install fzf and fd on CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,17 +23,8 @@ jobs:
         with:
           plugins: jorgebucaran/fishtape ilancosman/clownfish $GITHUB_WORKSPACE
 
-      - name: Install fzf
-        run: |
-          git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
-          ~/.fzf/install
-
-      - name: Install fd
-        run: |
-          git clone https://github.com/sharkdp/fd
-          cd fd
-          cargo build
-          cargo install --path .
+      - name: Install fzf and fd
+        run: brew install fzf fd
 
       - name: Run full test suite
         run: fishtape tests/*/*.fish


### PR DESCRIPTION
Who knew https://docs.brew.sh/Homebrew-on-Linux existed? This is at least 5x faster and way less code.
Follow up from https://github.com/PatrickF1/fzf.fish/pull/137/files#r599225253