### PR TITLE
[Search files] include hidden files if current token has a leading dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 - **Remarks**
   - prepends `./` to the selection if only one selection is made and it becomes the only token on the command line, making it easy to execute if an executable, or cd into if a directory (see [cd docs][])
   - if the current token is a directory with a trailing slash (e.g. `functions/<CURSOR>`), then search will be scoped to that directory
+  - if the current token has a leading dot (e.g. `.<CURSOR>`), then search will include hidden files
   - ignores files that are also ignored by git
   - <kbd>Tab</kbd> to multi-select
 

--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -11,6 +11,12 @@ function __fzf_search_current_dir --description "Search the current directory. R
     # unescape token because it's already quoted so backslashes will mess up the path
     set unescaped_exp_token (string unescape -- $expanded_token)
 
+    # If the current token has a leading dot,
+    # then include hidden files in the search.
+    if string match --quiet -- ".*" $token
+        set --append fd_opts --hidden
+    end
+
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
     if string match --quiet -- "*/" $token && test -d "$unescaped_exp_token"


### PR DESCRIPTION
While it makes sense to exclude hidden files by default in #126, it actually makes the function less accessible.
Hidden files are actually being searched for quite frequently, but keeping `--hidden` in `fzf_fd_opts`  makes the changes meaningless. Something like `bind \e\cf "fzf_fd_opts=--hidden __fzf_search_current_dir"` isn't intuitive as well.

What if we include hidden files if current token has a leading dot?

- This is the same logic behind *if the current token is a directory with a trailing slash, then search will be scoped to that directory*
- This can been seen in other places, for example Alfred, which only shows hidden files if you first type a dot.

I will add test for this if you like the idea.

P.S. I know you are trying to avoid introducing more complexity to search files, and honestly I don't feel like it too. That's why this PR is **not adding new features** (like prepending `./`) but **providing sensible search defaults**.