### PR TITLE
[Search git log] improve compatibility with older git versions

### DIFF
--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -6,10 +6,10 @@ function __fzf_search_git_log --description "Search the output of git log and pr
         # See similar comment in __fzf_search_shell_variables.fish.
         set --local --export SHELL (command --search fish)
 
+        # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
+        # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
         set log_fmt_str '%C(bold blue)%h%C(reset) - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
         set selected_log_line (
-            # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
-            # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
             git log --color=always --format=format:$log_fmt_str --date=short | \
             fzf --ansi \
                 --tiebreak=index \

--- a/functions/__fzf_search_git_log.fish
+++ b/functions/__fzf_search_git_log.fish
@@ -6,11 +6,11 @@ function __fzf_search_git_log --description "Search the output of git log and pr
         # See similar comment in __fzf_search_shell_variables.fish.
         set --local --export SHELL (command --search fish)
 
-        set log_fmt_str '%C(bold blue)%h%C(reset) - %C(cyan)%as%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
+        set log_fmt_str '%C(bold blue)%h%C(reset) - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
         set selected_log_line (
             # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
             # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
-            git log --color=always --format=format:$log_fmt_str | \
+            git log --color=always --format=format:$log_fmt_str --date=short | \
             fzf --ansi \
                 --tiebreak=index \
                 --preview='git show --color=always {1}' \


### PR DESCRIPTION
`%as` is added in [Git 2.25.0](https://git-scm.com/docs/git-log/2.25.0#Documentation/git-log.txt-emasem), and unfortunately I'm stuck on older Git versions on some machines, this PR makes fzf.fish compatible with them.

Or if you reject the change, you should also add minimal Git version requirement to README.