### PR TITLE
Make C-R acts as expected(redo) in vi-mode

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -8,7 +8,6 @@ set --global fzf_search_vars_cmd '__fzf_search_shell_variables (set --show | psu
 if not set --query fzf_fish_custom_keybindings
     # \cf is Ctrl+f
     bind \cf __fzf_search_current_dir
-    bind \cr __fzf_search_history
     bind \cv $fzf_search_vars_cmd
     # The following two key binding use Alt as an additional modifier key to avoid conflicts
     bind \e\cl __fzf_search_git_log
@@ -21,6 +20,8 @@ if not set --query fzf_fish_custom_keybindings
         bind --mode insert \cv $fzf_search_vars_cmd
         bind --mode insert \e\cl __fzf_search_git_log
         bind --mode insert \e\cs __fzf_search_git_status
+    else # only override Ctrl+R when no vi-mode included in keybindings.
+        bind \cr __fzf_search_history
     end
 end
 


### PR DESCRIPTION
The latest worktree of fish-shell has reset `u` and `C-r` shortcuts in vi-mode to acts same with vim(undo, redo separately), 
fzf.fish's keybinding on `C-r` will override this redo behavior in fish vi-mode, so I change it slightly and tested on the updated version, seems works as expected,  please give a look on it.

If this modification does not solve the problem properly, feel free to close it.

related issue: https://github.com/fish-shell/fish-shell/pull/7908