### PR TITLE
[Search files] Preview binary files using hexyl

### DIFF
--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -5,7 +5,12 @@ function __fzf_preview_file --description "Print a preview for the given file ba
     set file_path $argv
 
     if test -f "$file_path" # regular file
-        bat --style=numbers --color=always "$file_path"
+        if file --mime-encoding "$file_path" | string match -rq ': binary$'
+          file --uncompress "$file_path" | fold -s
+          hexyl --border=none --color=always --length=512 "$file_path"
+        else
+          bat --style=numbers --color=always "$file_path"
+        end
     else if test -d "$file_path" # directory
         if set --query fzf_preview_dir_cmd
             # need to escape quotes to make sure eval receives file_path as a single arg


### PR DESCRIPTION
This uses `hexyl`, which is a very nice (and fast!) hex viewer.

BSD `file` is also used. While the options specified are not POSIX, the almost
universally used BSD (*BSD, macOS, Linux) version (`man file.1`) accepts
these options/has compatible output. I have not tested Solaris/AIX/any other
more exotic Unix, but I suspect they are not major concerns.

Given we depend on sharkdp's other tools (fd, bat), this seems to be an easy
choice. Guards could be added to let the user know they're missing necessary
deps (or just to stub out features if the relevant tool is not installed), but
given use of fd/bat is not guarded I think it's external to this PR, and should
be added separately if deemed desirable.
