### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 - **Preview window:** file with syntax highlighting, directory contents, or file type
 - **Remarks**
   - prepends `./` to the selection if only one selection is made and it becomes the only token on the command line, making it easy to execute if an executable, or cd into if a directory (see [cd docs][])
-  - if the current token is a directory with a trailing slash (e.g. `functions/<CURSOR>`), then search will be scoped to that directory
+  - if the current token is a directory with a trailing slash (e.g. `.config/<CURSOR>`), then that directory will be searched instead
   - ignores files that are also ignored by git
   - <kbd>Tab</kbd> to multi-select
 
@@ -94,7 +94,7 @@ set --universal fzf_fish_custom_keybindings
 
 Do not try to set `fzf_fish_custom_keybindings` in your `config.fish` because the key binding configuration is sourced first on shell startup and so will not see it.
 
-Next, set your own key bindings by following [conf.d/fzf.fish][] as an example.
+Next, set your own key bindings by following [conf.d/fzf.fish][] as an example. Your search variables command should reference the `fzf_search_vars_cmd` variable instead of hardcoding the command.
 
 ### Pass fzf options to all commands
 
@@ -160,7 +160,7 @@ set fzf_fd_opts --hidden --exclude=.git
 
 ### Change the key binding for a single command
 
-See the [FAQ][] Wiki page.
+See the [Cookbook][] Wiki page.
 
 ## Prior art
 
@@ -171,23 +171,23 @@ If `fzf.fish` is a useful plugin, it is by standing on the shoulder of giants. T
 Need help? These Wiki pages can guide you:
 
 - [Troubleshooting][troubleshooting]
-- [FAQ][faq]
+- [Cookbook][cookbook]
 
 [actions]: https://github.com/PatrickF1/fzf.fish/actions
 [awesome badge]: https://awesome.re/mentioned-badge.svg
 [awesome fish]: https://git.io/awsm.fish
 [bat]: https://github.com/sharkdp/bat
 [build status badge]: https://img.shields.io/github/workflow/status/patrickf1/fzf.fish/CI
-[custom preview command]: functions/__fzf_preview_file.fish#L7
 [cd docs]: https://fishshell.com/docs/current/cmds/cd.html
 [command history search]: images/command_history.gif
 [conf.d/fzf.fish]: conf.d/fzf.fish
-[faq]: https://github.com/PatrickF1/fzf.fish/wiki/FAQ
+[cookbook]: https://github.com/PatrickF1/fzf.fish/wiki/Cookbook
+[custom preview command]: functions/__fzf_preview_file.fish#L7
 [fd]: https://github.com/sharkdp/fd
 [file search]: images/directory.gif
+[fish extension]: https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish
 [fish]: https://fishshell.com
 [fisher]: https://github.com/jorgebucaran/fisher
-[fish extension]: https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish
 [fzf_default_opts]: https://github.com/junegunn/fzf#environment-variables
 [fzf]: https://github.com/junegunn/fzf
 [git log search]: images/git_log.gif

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ set --universal fzf_fish_custom_keybindings
 
 Do not try to set `fzf_fish_custom_keybindings` in your `config.fish` because the key binding configuration is sourced first on shell startup and so will not see it.
 
-Next, set your own key bindings by following [conf.d/fzf.fish][] as an example. Your search variables command should reference the `fzf_search_vars_cmd` variable instead of hardcoding the command.
+Next, set your own key bindings by following [conf.d/fzf.fish][] as an example. Your search variables key binding should reference the `fzf_search_vars_cmd` variable instead of hardcoding the command.
 
 ### Pass fzf options to all commands
 
@@ -184,7 +184,6 @@ Find the answers to these questions and more in the GitHub [Wiki][]:
 [custom preview command]: functions/__fzf_preview_file.fish#L7
 [fd]: https://github.com/sharkdp/fd
 [file search]: images/directory.gif
-[fish extension]: https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish
 [fish]: https://fishshell.com
 [fisher]: https://github.com/jorgebucaran/fisher
 [fzf_default_opts]: https://github.com/junegunn/fzf#environment-variables
@@ -192,13 +191,11 @@ Find the answers to these questions and more in the GitHub [Wiki][]:
 [git log search]: images/git_log.gif
 [git status select]: images/git_status.gif
 [ilancosman/tide]: https://github.com/IlanCosman/tide
-[jethrokuan/fzf]: https://github.com/jethrokuan/fzf
 [latest release badge]: https://img.shields.io/github/v/release/patrickf1/fzf.fish
 [prior art]: https://github.com/PatrickF1/fzf.fish/wiki/Prior-Art
 [releases]: https://github.com/patrickf1/fzf.fish/releases
 [shell variables search]: images/shell_variables.gif
 [troubleshooting]: https://github.com/PatrickF1/fzf.fish/wiki/Troubleshooting
 [universal variable]: https://fishshell.com/docs/current/#more-on-universal-variables
-[unix philosophy]: https://en.wikipedia.org/wiki/Unix_philosophy
 [var scope]: https://fishshell.com/docs/current/#variable-scope
 [wiki]: https://github.com/PatrickF1/fzf.fish/wiki

--- a/README.md
+++ b/README.md
@@ -164,13 +164,12 @@ See the [Cookbook][] Wiki page.
 
 ## Further reading
 
-Curious about how `fzf.fish` [compares][prior art] to [jethrokuan/fzf][] or fzf's out-of-the-box [Fish extension][]?
+Find the answers to these questions and more in the GitHub [Wiki][]:
 
-Need help [troubleshooting][] or [integrating][cookbook] fzf.fish into your workflow?
-
-Interested in the design philosophy of fzf.fish?
-
-Find all of that and more in the [Wiki][].
+- How does `fzf.fish` [compare][prior art] to other popular fzf-fish plugins?
+- Why isn't this [feature working][troubleshooting] for me?
+- How do I [make the most][cookbook] of `fzf.fish` in my workflow?
+- How can I [contribute][] to this plugin?
 
 [actions]: https://github.com/PatrickF1/fzf.fish/actions
 [awesome badge]: https://awesome.re/mentioned-badge.svg
@@ -180,6 +179,7 @@ Find all of that and more in the [Wiki][].
 [cd docs]: https://fishshell.com/docs/current/cmds/cd.html
 [command history search]: images/command_history.gif
 [conf.d/fzf.fish]: conf.d/fzf.fish
+[contribute]: https://github.com/PatrickF1/fzf.fish/wiki/Contributing
 [cookbook]: https://github.com/PatrickF1/fzf.fish/wiki/Cookbook
 [custom preview command]: functions/__fzf_preview_file.fish#L7
 [fd]: https://github.com/sharkdp/fd

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ See the [Cookbook][] Wiki page.
 
 ## Further reading
 
-Find the answers to these questions and more in the GitHub [Wiki][]:
+Find answers to these questions and more in the [project Wiki][wiki]:
 
 - How does `fzf.fish` [compare][prior art] to other popular fzf-fish plugins?
 - Why isn't this [feature working][troubleshooting] for me?

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ See the [Cookbook][] Wiki page.
 
 Find answers to these questions and more in the [project Wiki][wiki]:
 
-- How does `fzf.fish` [compare][prior art] to other popular fzf-fish plugins?
+- How does `fzf.fish` [compare][prior art] to other popular fzf plugins for fish?
 - Why isn't this [feature working][troubleshooting] for me?
-- How do I [make the most][cookbook] of `fzf.fish` in my workflow?
+- How can I [integrate][cookbook] this plugin into my workflow?
 - How can I [contribute][] to this plugin?
 
 [actions]: https://github.com/PatrickF1/fzf.fish/actions

--- a/README.md
+++ b/README.md
@@ -162,16 +162,15 @@ set fzf_fd_opts --hidden --exclude=.git
 
 See the [Cookbook][] Wiki page.
 
-## Prior art
+## Further reading
 
-If `fzf.fish` is a useful plugin, it is by standing on the shoulder of giants. There are two other fzf integrations for Fish worth regarding: [jethrokuan/fzf][] and fzf's out-of-the-box [Fish extension][]. The [Prior Art][] Wiki page explains how `fzf.fish` compares to and improves on them.
+Curious about how `fzf.fish` [compares][prior art] to [jethrokuan/fzf][] or fzf's out-of-the-box [Fish extension][]?
 
-## Troubleshooting & FAQ
+Need help [troubleshooting][] or [integrating][cookbook] fzf.fish into your workflow?
 
-Need help? These Wiki pages can guide you:
+Interested in the design philosophy of fzf.fish?
 
-- [Troubleshooting][troubleshooting]
-- [Cookbook][cookbook]
+Find all of that and more in the [Wiki][].
 
 [actions]: https://github.com/PatrickF1/fzf.fish/actions
 [awesome badge]: https://awesome.re/mentioned-badge.svg
@@ -202,3 +201,4 @@ Need help? These Wiki pages can guide you:
 [universal variable]: https://fishshell.com/docs/current/#more-on-universal-variables
 [unix philosophy]: https://en.wikipedia.org/wiki/Unix_philosophy
 [var scope]: https://fishshell.com/docs/current/#variable-scope
+[wiki]: https://github.com/PatrickF1/fzf.fish/wiki


### PR DESCRIPTION
Advertise Wiki better and as its own major entity
Point out shell variable command variable `fzf_search_vars_cmd`
Rename Wiki page FAQ to cookbook