### PR TITLE
[Search directory] fix preview when base dir contains spaces (patch 3)

### DIFF
--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -16,14 +16,14 @@ function __fzf_preview_file --description "Print a preview for the given file ba
     else if test -f "$file_path" # regular file
         if set --query fzf_preview_file_cmd
             # need to escape quotes to make sure eval receives file_path as a single arg
-            eval $fzf_preview_file_cmd \"$file_path\"
+            eval "$fzf_preview_file_cmd '$file_path'"
         else
             bat --style=numbers --color=always "$file_path"
         end
     else if test -d "$file_path" # directory
         if set --query fzf_preview_dir_cmd
             # see above
-            eval $fzf_preview_dir_cmd \"$file_path\"
+            eval "$fzf_preview_dir_cmd '$file_path'"
         else
             # -A list hidden files as well, except for . and ..
             # -F helps classify files by appending symbols after the file name


### PR DESCRIPTION
There is still, yet another bug, afflicting the search directory feature. To reproduce, `set -x fzf_preview_dir_cmd ls` and search with a base directory with spaces in its name:

![image](https://user-images.githubusercontent.com/44045911/117938954-2a0e7e00-b33a-11eb-959d-54156425e42d.png)
![image](https://user-images.githubusercontent.com/44045911/117938977-3266b900-b33a-11eb-9363-4f982d86b4ce.png)

As it turned out, escaping quotes isn't a good idea either. The correct way to use `eval` is to quote the code entirely. Single quotes for parameter is used for programs instead.

This is a followup from #137 and #152 