### PR TITLE
Only bind keys in normal mode if using `fish_default_key_bindings`

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -8,21 +8,20 @@ set --global fzf_search_vars_cmd '__fzf_search_shell_variables (set --show | psu
 if not set --query fzf_fish_custom_keybindings
     function __fzf_fish_key_bindings --on-variable fish_key_bindings
         if test "$fish_key_bindings" = fish_default_key_bindings
-            # \cf is Ctrl+f
-            bind \cf __fzf_search_current_dir
-            bind \cr __fzf_search_history
-            bind \cv $fzf_search_vars_cmd
-            # The following two key binding use Alt as an additional modifier key to avoid conflicts
-            bind \e\cl __fzf_search_git_log
-            bind \e\cs __fzf_search_git_status
+            set modes default insert
         else
-            # set up the same key bindings for insert mode if not using fish_default_key_bindings
-            bind --mode insert \cf __fzf_search_current_dir
-            bind --mode insert \cr __fzf_search_history
-            bind --mode insert \cv $fzf_search_vars_cmd
-            bind --mode insert \e\cl __fzf_search_git_log
-            bind --mode insert \e\cs __fzf_search_git_status
+            set modes insert default
         end
+
+        # \cf is Ctrl+f
+        bind --mode $modes[1] \cf __fzf_search_current_dir
+        bind --mode $modes[1] \cr __fzf_search_history
+        bind --mode $modes[1] \cv $fzf_search_vars_cmd
+        # The following two key bindings use Alt as an additional modifier key to avoid conflicts
+        bind --mode $modes[1] \e\cl __fzf_search_git_log
+        bind --mode $modes[1] \e\cs __fzf_search_git_status
+        # Erase previous bingdings
+        bind --mode $modes[2] --erase \cf \cr \cv \e\cl \e\cs
     end
 
     __fzf_fish_key_bindings

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -15,8 +15,8 @@ if not set --query fzf_fish_custom_keybindings
             # The following two key binding use Alt as an additional modifier key to avoid conflicts
             bind \e\cl __fzf_search_git_log
             bind \e\cs __fzf_search_git_status
-        # set up the same key bindings for insert mode if not using fish_default_key_bindings
         else
+            # set up the same key bindings for insert mode if not using fish_default_key_bindings
             bind --mode insert \cf __fzf_search_current_dir
             bind --mode insert \cr __fzf_search_history
             bind --mode insert \cv $fzf_search_vars_cmd

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -6,22 +6,26 @@ set --global fzf_search_vars_cmd '__fzf_search_shell_variables (set --show | psu
 
 # Set up the default, mnemonic key bindings unless the user has chosen to customize them
 if not set --query fzf_fish_custom_keybindings
-    if test "$fish_key_bindings" = fish_default_key_bindings
-        # \cf is Ctrl+f
-        bind \cf __fzf_search_current_dir
-        bind \cr __fzf_search_history
-        bind \cv $fzf_search_vars_cmd
-        # The following two key binding use Alt as an additional modifier key to avoid conflicts
-        bind \e\cl __fzf_search_git_log
-        bind \e\cs __fzf_search_git_status
-    # set up the same key bindings for insert mode if not using fish_default_key_bindings
-    else
-        bind --mode insert \cf __fzf_search_current_dir
-        bind --mode insert \cr __fzf_search_history
-        bind --mode insert \cv $fzf_search_vars_cmd
-        bind --mode insert \e\cl __fzf_search_git_log
-        bind --mode insert \e\cs __fzf_search_git_status
+    function __fzf_fish_key_bindings --on-variable fish_key_bindings
+        if test "$fish_key_bindings" = fish_default_key_bindings
+            # \cf is Ctrl+f
+            bind \cf __fzf_search_current_dir
+            bind \cr __fzf_search_history
+            bind \cv $fzf_search_vars_cmd
+            # The following two key binding use Alt as an additional modifier key to avoid conflicts
+            bind \e\cl __fzf_search_git_log
+            bind \e\cs __fzf_search_git_status
+        # set up the same key bindings for insert mode if not using fish_default_key_bindings
+        else
+            bind --mode insert \cf __fzf_search_current_dir
+            bind --mode insert \cr __fzf_search_history
+            bind --mode insert \cv $fzf_search_vars_cmd
+            bind --mode insert \e\cl __fzf_search_git_log
+            bind --mode insert \e\cs __fzf_search_git_status
+        end
     end
+
+    __fzf_fish_key_bindings
 end
 
 # If FZF_DEFAULT_OPTS is not set, then set some sane defaults. This also affects fzf outside of this plugin.

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -6,16 +6,16 @@ set --global fzf_search_vars_cmd '__fzf_search_shell_variables (set --show | psu
 
 # Set up the default, mnemonic key bindings unless the user has chosen to customize them
 if not set --query fzf_fish_custom_keybindings
-    # \cf is Ctrl+f
-    bind \cf __fzf_search_current_dir
-    bind \cr __fzf_search_history
-    bind \cv $fzf_search_vars_cmd
-    # The following two key binding use Alt as an additional modifier key to avoid conflicts
-    bind \e\cl __fzf_search_git_log
-    bind \e\cs __fzf_search_git_status
-
-    # set up the same key bindings for insert mode if using fish_vi_key_bindings
-    if test "$fish_key_bindings" = fish_vi_key_bindings -o "$fish_key_bindings" = fish_hybrid_key_bindings
+    if test "$fish_key_bindings" = fish_default_key_bindings
+        # \cf is Ctrl+f
+        bind \cf __fzf_search_current_dir
+        bind \cr __fzf_search_history
+        bind \cv $fzf_search_vars_cmd
+        # The following two key binding use Alt as an additional modifier key to avoid conflicts
+        bind \e\cl __fzf_search_git_log
+        bind \e\cs __fzf_search_git_status
+    # set up the same key bindings for insert mode if not using fish_default_key_bindings
+    else
         bind --mode insert \cf __fzf_search_current_dir
         bind --mode insert \cr __fzf_search_history
         bind --mode insert \cv $fzf_search_vars_cmd


### PR DESCRIPTION
In Vi mode, <kbd>Ctrl</kbd> + <kbd>r</kbd> is [used for redo](https://github.com/fish-shell/fish-shell/blob/678fa2e6a9a9319f270f71ae5d3a7e14fd54bc21/share/functions/fish_vi_key_bindings.fish#L105) by default, which conflicts with `__fzf_search_history`. I believe the correct way to handle this is to only bind keys in insert mode.

Also added handler for mode switching like [autopair.fish](https://github.com/jorgebucaran/autopair.fish/blob/1222311994a0730e53d8e922a759eeda815fcb62/conf.d/autopair.fish#L7-L31).