### PR TITLE
[Search directory] fix specifying base directories using quotes

### DIFF
--- a/functions/__fzf_search_current_dir.fish
+++ b/functions/__fzf_search_current_dir.fish
@@ -13,7 +13,7 @@ function __fzf_search_current_dir --description "Search the current directory. R
 
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
-    if string match --quiet -- "*/" $token && test -d "$unescaped_exp_token"
+    if string match --quiet -- "*/" $unescaped_exp_token && test -d "$unescaped_exp_token"
         set --append fd_opts --base-directory=$unescaped_exp_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --prepend fzf_arguments --prompt="$unescaped_exp_token" --preview="__fzf_preview_file $expanded_token{}"


### PR DESCRIPTION
This was presented in the [initial PR](https://github.com/PatrickF1/fzf.fish/pull/75) when the feature is added, but was (possibly mistakenly) broken by #137.