### PR TITLE
[Search directory] fix previewing symlinks containing spaces

### DIFF
--- a/functions/__fzf_preview_file.fish
+++ b/functions/__fzf_preview_file.fish
@@ -6,7 +6,7 @@ function __fzf_preview_file --description "Print a preview for the given file ba
 
     if test -L "$file_path" # symlink
         # notify user and recurse on the target of the symlink, which can be any of these file types
-        set -l target_path (realpath $file_path)
+        set -l target_path (realpath "$file_path")
 
         set_color yellow
         echo "'$file_path' is a symlink to '$target_path'."


### PR DESCRIPTION
Due to #152, this is broken while all other `$file_path` references have been correctly quoted.

![image](https://user-images.githubusercontent.com/44045911/118979481-181c8300-b9ab-11eb-8a2e-8ad4689ca538.png)
