### PR TITLE
[Search variables] enable selecting multiple variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Use `fzf.fish` to interactively find and insert into the command line:
 - **Preview window:** the scope info and values of the variable
 - **Remarks**
   - `$history` is excluded for technical reasons so use the search command history feature instead to inspect it
+  - <kbd>Tab</kbd> to multi-select
 
 _The prompt used in the screencasts was created using [IlanCosman/tide][]._
 

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -31,7 +31,8 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
 
     set variable_names_selected (
         printf '%s\n' $all_variable_names |
-        fzf --multi --preview "__fzf_extract_var_info {} $set_show_output" \
+        fzf --preview "__fzf_extract_var_info {} $set_show_output" \
+            --multi \
             --query=$cleaned_curr_token \
             $fzf_shell_vars_opts
     )

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -39,9 +39,10 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     if test $status -eq 0
         # If the current token begins with a $, do not overwrite the $ when
         # replacing the current token with the selected variable.
+        # Uses brace expansion to prepend $ to each variable name.
         commandline --current-token --replace (
             if string match --quiet -- '$*' $current_token
-                string join " " \$$variable_names_selected
+                string join " " \${$variable_names_selected}
             else
                 string join " " $variable_names_selected
             end

--- a/functions/__fzf_search_shell_variables.fish
+++ b/functions/__fzf_search_shell_variables.fish
@@ -29,9 +29,9 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     # with a $, remove it from the query so that it will better match the variable names
     set cleaned_curr_token (string replace -- '$' '' $current_token)
 
-    set variable_name (
+    set variable_names_selected (
         printf '%s\n' $all_variable_names |
-        fzf --preview "__fzf_extract_var_info {} $set_show_output" \
+        fzf --multi --preview "__fzf_extract_var_info {} $set_show_output" \
             --query=$cleaned_curr_token \
             $fzf_shell_vars_opts
     )
@@ -39,11 +39,13 @@ function __fzf_search_shell_variables --argument-names set_show_output set_names
     if test $status -eq 0
         # If the current token begins with a $, do not overwrite the $ when
         # replacing the current token with the selected variable.
-        if string match --quiet -- '$*' $current_token
-            commandline --current-token --replace \$$variable_name
-        else
-            commandline --current-token --replace $variable_name
-        end
+        commandline --current-token --replace (
+            if string match --quiet -- '$*' $current_token
+                string join " " \$$variable_names_selected
+            else
+                string join " " $variable_names_selected
+            end
+        )
     end
 
     commandline --function repaint

--- a/tests/search_shell_variables/$_in_curr_token.fish
+++ b/tests/search_shell_variables/$_in_curr_token.fish
@@ -1,7 +1,7 @@
 mock commandline \* "" # mock all other commandline executions to do nothing
-mock commandline --current-token "echo \\\$variable"
+mock commandline --current-token "echo \\\$variable" # simulate current token starting with $
 mock commandline "--current-token --replace" "echo \$argv" # instead of updating commandline with the result, just output it
-mock fzf \* "echo selection"
+mock fzf \* "echo a\nb\nc"
 
 set actual (eval $fzf_search_vars_cmd)
-@test "doesn't overwrite \$ when replacing current token with selected variable" "$actual" = "\$selection"
+@test "doesn't overwrite \$ when replacing current token with selected variable" "$actual" = "\$a \$b \$c"


### PR DESCRIPTION
This feature started with the discussion in https://github.com/PatrickF1/fzf.fish/pull/73#discussion_r552143666.

After such a long time I'm convinced that keeping `--multi` in `FZF_DEFAULT_OPTS` is not a good idea, but we can make more functions allow multiple selections by default.

IMO, out of 5 current fzf.fish functions, only `__fzf_search_history` does not need `--multi`. `__fzf_search_current_dir` and `__fzf_search_git_status` already has `--multi` by default, which is natural since they deal with files.

`__fzf_search_shell_variables` joins the party in this PR, the most prominent usage I can think of now is `set -e` multiple variables.

As for `__fzf_search_git_log`, that will be in a separate PR since we may need to discuss how to handle multiple selections there (it's not as simple as `string join " "`).