### PR TITLE
[Search directory] fix quick directory change for hidden directories

### DIFF
--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -34,7 +34,8 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
         if test (count $file_paths_selected) = 1
             set commandline_tokens (commandline --tokenize)
-            if test "$commandline_tokens" = "$token"
+            set file_selected $file_paths_selected[1]
+            if test "$commandline_tokens" = "$token" -a -d "$file_selected"
                 set file_paths_selected ./$file_paths_selected
             end
         end

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -33,7 +33,6 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # - the user was in the middle of inputting the first token,
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
         if test (count $file_paths_selected) = 1
-                && not string match --quiet --regex "^\.?/" $file_paths_selected
             set commandline_tokens (commandline --tokenize)
             if test "$commandline_tokens" = "$current_token"
                 set file_paths_selected ./$file_paths_selected

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -34,7 +34,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # - and the path doesn't already begin with a dot or slash
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
         if test (count $file_paths_selected) = 1 \
-                && not string match --quiet --regex "^[.|/]" $file_paths_selected
+                && not string match --quiet --regex "^\.?/" $file_paths_selected
             set commandline_tokens (commandline --tokenize)
             if test "$commandline_tokens" = "$current_token"
                 set file_paths_selected ./$file_paths_selected

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -31,7 +31,6 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # automatically prepend ./ to the selected path if
         # - only one path was selected,
         # - the user was in the middle of inputting the first token,
-        # - and the path doesn't already begin with a / or ./
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
         if test (count $file_paths_selected) = 1 \
                 && not string match --quiet --regex "^\.?/" $file_paths_selected

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -32,7 +32,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # - only one path was selected,
         # - the user was in the middle of inputting the first token,
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
-        if test (count $file_paths_selected) = 1 \
+        if test (count $file_paths_selected) = 1
                 && not string match --quiet --regex "^\.?/" $file_paths_selected
             set commandline_tokens (commandline --tokenize)
             if test "$commandline_tokens" = "$current_token"

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -34,7 +34,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
         if test (count $file_paths_selected) = 1
             set commandline_tokens (commandline --tokenize)
-            if test "$commandline_tokens" = "$current_token"
+            if test "$commandline_tokens" = "$token"
                 set file_paths_selected ./$file_paths_selected
             end
         end

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -31,7 +31,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # automatically prepend ./ to the selected path if
         # - only one path was selected,
         # - the user was in the middle of inputting the first token,
-        # - and the path doesn't already begin with a dot or slash
+        # - and the path doesn't already begin with a / or ./
         # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
         if test (count $file_paths_selected) = 1 \
                 && not string match --quiet --regex "^\.?/" $file_paths_selected


### PR DESCRIPTION
Fixes #171 by making `.` optional but `/` required when deciding not to prepend `./`.