### PR TITLE
Skip config if not in interactive mode

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run full test suite
         run: fishtape tests/*/*.fish
-        shell: fish --interactive {0}
+        shell: fish {0}
         # timeout in case tests get stuck on fzf
         timeout-minutes: 3
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run full test suite
         run: fishtape tests/*/*.fish
-        shell: fish {0}
+        shell: fish --interactive {0}
         # timeout in case tests get stuck on fzf
         timeout-minutes: 3
 

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -5,7 +5,12 @@
 set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub) (set --names | psub)'
 
 # Skip rest of the config if not in interactive mode to speed shell startup a little
-status is-interactive || exit
+# Check for $CI environment variable [1] before fishtape issue [2] is resolved
+# [1] https://github.com/jorgebucaran/fishtape/issues/63
+# [2] https://docs.github.com/actions/reference/environment-variables#default-environment-variables
+if not status is-interactive && test "$CI" != true
+    exit
+end
 
 # Install the default bindings, which are mnemonic and minimally conflict with fish's preset bindings
 fzf_configure_bindings

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -6,8 +6,8 @@ set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub)
 
 # Skip rest of the config if not in interactive mode to speed up shell startup
 # Check for $CI environment variable [1] before fishtape issue [2] is resolved
-# [1] https://github.com/jorgebucaran/fishtape/issues/63
-# [2] https://docs.github.com/actions/reference/environment-variables#default-environment-variables
+# [1] https://docs.github.com/actions/reference/environment-variables#default-environment-variables
+# [2] https://github.com/jorgebucaran/fishtape/issues/63
 if not status is-interactive && test "$CI" != true
     exit
 end

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -1,16 +1,14 @@
+# fzf.fish is only meant to be used in interactive mode. If not in interactive mode and not in CI, skip the config to speed up shell startup
+if not status is-interactive && test "$CI" != true
+    exit
+end
+
 # Because of scoping rules, to capture the shell variables exactly as they are, we must read
 # them before even executing _fzf_search_variables. We use psub to store the
 # variables' info in temporary files and pass in the filenames as arguments.
 # # This variable is global so that it can be referenced by fzf_configure_bindings and in tests
 set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub) (set --names | psub)'
 
-# Skip rest of the config if not in interactive mode to speed up shell startup
-# Check for $CI environment variable [1] before fishtape issue [2] is resolved
-# [1] https://docs.github.com/actions/reference/environment-variables#default-environment-variables
-# [2] https://github.com/jorgebucaran/fishtape/issues/63
-if not status is-interactive && test "$CI" != true
-    exit
-end
 
 # Install the default bindings, which are mnemonic and minimally conflict with fish's preset bindings
 fzf_configure_bindings

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -4,7 +4,7 @@
 # # This variable is global so that it can be referenced by fzf_configure_bindings and in tests
 set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub) (set --names | psub)'
 
-# Skip rest of the config if not in interactive mode to speed shell startup a little
+# Skip rest of the config if not in interactive mode to speed up shell startup
 # Check for $CI environment variable [1] before fishtape issue [2] is resolved
 # [1] https://github.com/jorgebucaran/fishtape/issues/63
 # [2] https://docs.github.com/actions/reference/environment-variables#default-environment-variables

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -4,6 +4,9 @@
 # # This variable is global so that it can be referenced by fzf_configure_bindings and in tests
 set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub) (set --names | psub)'
 
+# Skip rest of the config if not in interactive mode to speed shell startup a little
+status is-interactive || exit
+
 # Install the default bindings, which are mnemonic and minimally conflict with fish's preset bindings
 fzf_configure_bindings
 


### PR DESCRIPTION
All of fzf.fish's features are only relevant and helpful in interactive mode. However, its config gets sourced even in non-interactive mode. So, let's skip configuration in non-interactive mode to make non-interactive fish shells a bit faster. This greatly benefits other plugins as well; for example [tide](https://github.com/IlanCosman/tide) makes use of non-interactive fish shells extensively.