### PR TITLE
[Search directory] Append / instead of prepending ./ for quick cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use `fzf.fish` to interactively find and insert different shell entities into th
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd> (`F` for file)
 - **Preview window:** file with syntax highlighting, directory contents, or file type
 - **Remarks**
-  - prepends `./` to the selection if only one selection is made and it becomes the only token on the command line, making it easy to execute if an executable, or cd into if a directory (see [cd docs][])
+  - appends `/` to the selection if it is a directory and the only path selected, making it quick to cd into (see [cd docs][])
   - if the current token is a directory with a trailing slash (e.g. `.config/<CURSOR>`), then that directory is searched instead
   - ignores files that are also ignored by git
   - <kbd>Tab</kbd> to multi-select

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use `fzf.fish` to interactively find and insert different shell entities into th
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd> (`F` for file)
 - **Preview window:** file with syntax highlighting, directory contents, or file type
 - **Remarks**
-  - appends `/` to the selection if it is a directory and the only path selected so you can hit <kbd>ENTER</kbd> to immediately cd into (see [cd docs][])
+  - appends `/` to the selection if it is a directory and the only path selected so you can hit <kbd>ENTER</kbd> to [immediately cd into it][cd docs]
   - if the current token is a directory with a trailing slash (e.g. `.config/<CURSOR>`), then that directory is searched instead
   - ignores files that are also ignored by git
   - <kbd>Tab</kbd> to multi-select

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use `fzf.fish` to interactively find and insert different shell entities into th
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd> (`F` for file)
 - **Preview window:** file with syntax highlighting, directory contents, or file type
 - **Remarks**
-  - appends `/` to the selection if it is a directory and the only path selected so you can hit <kbd>ENTER</kbd> to [immediately cd into it][cd docs]
+  - appends `/` if the selection is a directory and the only path selected so you can hit <kbd>ENTER</kbd> to [immediately cd into it][cd docs]
   - if the current token is a directory with a trailing slash (e.g. `.config/<CURSOR>`), then that directory is searched instead
   - ignores files that are also ignored by git
   - <kbd>Tab</kbd> to multi-select

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use `fzf.fish` to interactively find and insert different shell entities into th
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd> (`F` for file)
 - **Preview window:** file with syntax highlighting, directory contents, or file type
 - **Remarks**
-  - appends `/` to the selection if it is a directory and the only path selected, making it quick to cd into (see [cd docs][])
+  - appends `/` to the selection if it is a directory and the only path selected so you can hit <kbd>ENTER</kbd> to immediately cd into (see [cd docs][])
   - if the current token is a directory with a trailing slash (e.g. `.config/<CURSOR>`), then that directory is searched instead
   - ignores files that are also ignored by git
   - <kbd>Tab</kbd> to multi-select

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -25,19 +25,16 @@ function _fzf_search_directory --description "Search the current directory. Repl
 
 
     if test $status -eq 0
-        # Fish will implicitly take action on a path when a path is provided as the first token and it
-        # begins with a dot or slash. If the path is a directory, Fish will cd into it. If the path is
-        # an executable, Fish will execute it. To help users harness this convenient behavior, we
-        # automatically prepend ./ to the selected path if
+        # Fish will cd implicitly if a directory name ending in a slash is provided.
+        # To help the user leverage this feature, we automatically append / to the selected path if
         # - only one path was selected,
         # - the user was in the middle of inputting the first token,
-        # - and the path doesn't already begin with a dot or slash
-        # Then, the user only needs to hit Enter once more to potentially cd into or execute that path.
-        if test (count $file_paths_selected) = 1 \
-                && not string match --quiet --regex "^[.|/]" $file_paths_selected
+        # - the path is a directory
+        # Then, the user only needs to hit Enter once more to cd into that directory.
+        if test (count $file_paths_selected) = 1
             set commandline_tokens (commandline --tokenize)
-            if test "$commandline_tokens" = "$current_token"
-                set file_paths_selected ./$file_paths_selected
+            if test "$commandline_tokens" = "$token" -a -d "$file_paths_selected"
+                set file_paths_selected $file_paths_selected/
             end
         end
 

--- a/tests/search_current_dir/append_trailing_slash.fish
+++ b/tests/search_current_dir/append_trailing_slash.fish
@@ -15,4 +15,4 @@ set result (_fzf_search_directory)
 set dir_path conf.d
 mock fzf \* "echo $dir_path"
 set result (_fzf_search_directory)
-@test "appends / if exactly one selection and its a directory" "$result" = $dir_path
+@test "appends / if exactly one selection and it is a directory" "$result" = $dir_path/

--- a/tests/search_current_dir/appending_trailing_slash.fish
+++ b/tests/search_current_dir/appending_trailing_slash.fish
@@ -1,0 +1,18 @@
+# set up mocks needed for all the test cases
+mock commandline \* ""
+mock commandline "--current-token --replace --" "echo \$argv"
+mock fd \* ""
+
+mock fzf \* "echo -e conf.d\nfunctions"
+set result (_fzf_search_directory)
+@test "doesn't append / if more than one path selected" "$result" = "conf.d functions"
+
+set non_dir_path README.md
+mock fzf \* "echo $non_dir_path"
+set result (_fzf_search_directory)
+@test "doesn't append / if path is not a directory" "$result" = $non_dir_path
+
+set dir_path conf.d
+mock fzf \* "echo $dir_path"
+set result (_fzf_search_directory)
+@test "appends / if exactly one selection and its a directory" "$result" = $dir_path

--- a/tests/search_current_dir/no_dot_slash_if_unneeded.fish
+++ b/tests/search_current_dir/no_dot_slash_if_unneeded.fish
@@ -1,9 +1,0 @@
-# set everything up so that a path starting with / is outputted by fzf
-mock commandline \* ""
-mock commandline "--current-token --replace --" "echo \$argv"
-mock fd \* ""
-mock fzf \* "echo /Users/patrickf"
-
-# since there is already a /, no ./ should be prepended
-set result (_fzf_search_directory)
-@test "doesn't prepend ./ if path already starts with /" "$result" = /Users/patrickf


### PR DESCRIPTION
I decided appending / is a better, cleaner solution for quick cd than appending ./
- since prepending ./ is causing issues when the path starts with . or /, why not just append /? fd never appends / to its output so this is safe to do (see https://github.com/sharkdp/fd/issues/436)
- of course, we can't just append / to everything; we need to test if the path is actually a directory, but since we only do this when there's one path selected, it's not performance hindering
- a / at the end of only directories is cleaner, natural, and has a more comprehensible than prepending ./ to anything even when it's not needed
- the code and documentation become much more straightforward
- this will remove support for executables, which cuts back on product debt
- fixes #171 (is compatible with hidden directories)

This is about the same as the PR that started this all (#72) except we're using a trailing / instead.

Do note that symlink behavior changes if the directory has a trailing / (https://github.com/PatrickF1/fzf.fish/pull/185#issuecomment-873533385).