### PR TITLE
Fix bind error messages appearing in non-interactive windows

### DIFF
--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -1,14 +1,13 @@
-# fzf.fish is only meant to be used in interactive mode. If not in interactive mode and not in CI, skip the config to speed up shell startup
-if not status is-interactive && test "$CI" != true
-    exit
-end
-
 # Because of scoping rules, to capture the shell variables exactly as they are, we must read
 # them before even executing _fzf_search_variables. We use psub to store the
 # variables' info in temporary files and pass in the filenames as arguments.
 # # This variable is global so that it can be referenced by fzf_configure_bindings and in tests
 set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub) (set --names | psub)'
 
+# fzf.fish is only meant to be used in interactive mode. If not in interactive mode and not in CI, skip the config to speed up shell startup
+if not status is-interactive && test "$CI" != true
+    exit
+end
 
 # Install the default bindings, which are mnemonic and minimally conflict with fish's preset bindings
 fzf_configure_bindings

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -1,13 +1,14 @@
+# fzf.fish is only meant to be used in interactive mode. If not in interactive mode and not in CI, skip the config to speed up shell startup
+if not status is-interactive && test "$CI" != true
+    exit
+end
+
 # Because of scoping rules, to capture the shell variables exactly as they are, we must read
 # them before even executing _fzf_search_variables. We use psub to store the
 # variables' info in temporary files and pass in the filenames as arguments.
 # # This variable is global so that it can be referenced by fzf_configure_bindings and in tests
 set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub) (set --names | psub)'
 
-# fzf.fish is only meant to be used in interactive mode. If not in interactive mode and not in CI, skip the config to speed up shell startup
-if not status is-interactive && test "$CI" != true
-    exit
-end
 
 # Install the default bindings, which are mnemonic and minimally conflict with fish's preset bindings
 fzf_configure_bindings

--- a/functions/fzf_configure_bindings.fish
+++ b/functions/fzf_configure_bindings.fish
@@ -1,10 +1,9 @@
 # Always installs bindings for insert and default mode for simplicity and b/c it has almost no side-effect
 # https://gitter.im/fish-shell/fish-shell?at=60a55915ee77a74d685fa6b1
 function fzf_configure_bindings --description "Installs the default key bindings for fzf.fish with user overrides passed as options."
-    # no need to install bindings if not in interactive mode
-    if not status is-interactive && test "$CI" != true
-        return
-    end
+    # no need to install bindings if not in interactive mode or running tests
+    status is-interactive || test "$CI" = true; or return
+
     set options_spec h/help 'directory=?' 'git_log=?' 'git_status=?' 'history=?' 'variables=?'
     argparse --max-args=0 --ignore-unknown $options_spec -- $argv 2>/dev/null
     if test $status -ne 0

--- a/functions/fzf_configure_bindings.fish
+++ b/functions/fzf_configure_bindings.fish
@@ -33,7 +33,7 @@ function fzf_configure_bindings --description "Installs the default key bindings
             test -n $key_sequences[2] && bind --mode $mode $key_sequences[2] _fzf_search_git_log
             test -n $key_sequences[3] && bind --mode $mode $key_sequences[3] _fzf_search_git_status
             test -n $key_sequences[4] && bind --mode $mode $key_sequences[4] _fzf_search_history
-            test -n $key_sequences[5] && bind --mode $mode $key_sequences[5] $_fzf_search_vars_command
+            test -n $key_sequences[5] && bind --mode $mode $key_sequences[5] "$_fzf_search_vars_command"
         end
 
         function _fzf_uninstall_bindings --inherit-variable key_sequences

--- a/functions/fzf_configure_bindings.fish
+++ b/functions/fzf_configure_bindings.fish
@@ -1,6 +1,7 @@
 # Always installs bindings for insert and default mode for simplicity and b/c it has almost no side-effect
 # https://gitter.im/fish-shell/fish-shell?at=60a55915ee77a74d685fa6b1
 function fzf_configure_bindings --description "Installs the default key bindings for fzf.fish with user overrides passed as options."
+    status is-interactive || return 0
     set options_spec h/help 'directory=?' 'git_log=?' 'git_status=?' 'history=?' 'variables=?'
     argparse --max-args=0 --ignore-unknown $options_spec -- $argv 2>/dev/null
     if test $status -ne 0

--- a/functions/fzf_configure_bindings.fish
+++ b/functions/fzf_configure_bindings.fish
@@ -1,7 +1,10 @@
 # Always installs bindings for insert and default mode for simplicity and b/c it has almost no side-effect
 # https://gitter.im/fish-shell/fish-shell?at=60a55915ee77a74d685fa6b1
 function fzf_configure_bindings --description "Installs the default key bindings for fzf.fish with user overrides passed as options."
-    status is-interactive || return 0
+    # no need to install bindings if not in interactive mode
+    if not status is-interactive && test "$CI" != true
+        return
+    end
     set options_spec h/help 'directory=?' 'git_log=?' 'git_status=?' 'history=?' 'variables=?'
     argparse --max-args=0 --ignore-unknown $options_spec -- $argv 2>/dev/null
     if test $status -ne 0


### PR DESCRIPTION
This fixes #183, which is a resulting bug from #180.

## Explanation of the issue

#180 makes `$_fzf_search_vars_command` unavailable for non-interactive sessions. However, `fzf_configure_bindings` depends on that variable being available. If the user puts `fzf_configure_bindings` in their `config.fish`, `fzf_configure_bindings` gets executed in non-interactive sessions e.g. fzf preview windows or by tide, and the following line in the function...

https://github.com/PatrickF1/fzf.fish/blob/17d54b576919ee77644779db2dcae56d372a8830/functions/fzf_configure_bindings.fish#L33

...essentially becomes: 

```fish
test -n $key_sequences[5] && bind --mode $mode $key_sequences[5]
```

which results in error message like `bind --preset \cv fish_clipboard_paste` or `bind: No binding found for sequence '\cv'`.

## Solution
Don't execute the entirety of `fzf_configure_bindings` if not in interactive mode. And for good measure, quote `_fzf_search_vars_command` so that even if it does get executed, the bind command will run successfully.