### PR TITLE
Set SHELL and FZF_DEFAULT_OPTS in wrapper around fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Once you've found the `fzf_configure_bindings` command that produces the desired
 
 fzf supports setting default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable. If it is set, fzf implicitly prepends it to the options passed to it on every execution, scripted and interactive.
 
-By default, `fzf.fish` sets a sane `FZF_DEFAULT_OPTS` before it executes Fzf. However, If you export your own `FZF_DEFAULT_OPTS` variable, then `fzf.fish` will forgo setting it and yours will be used instead. See [functions/_fzf_wrapper.fish][] for more details.
+By default, `fzf.fish` sets a sane `FZF_DEFAULT_OPTS` before it executes Fzf. However, If you export your own `FZF_DEFAULT_OPTS` variable, then `fzf.fish` will forgo setting it and yours will be used instead. See [functions/\_fzf_wrapper.fish](functions/_fzf_wrapper.fish) for more details.
 
 ### Pass fzf options for a specific feature
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ Once you've found the `fzf_configure_bindings` command that produces the desired
 
 fzf supports setting default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable. If it is set, fzf implicitly prepends it to the options passed to it on every execution, scripted and interactive.
 
-To make fzf's interface friendlier, `fzf.fish` takes the liberty of setting a sane `FZF_DEFAULT_OPTS` if it is not already set. See [conf.d/fzf.fish][] for more details. This affects fzf even outside of this plugin. If you would like to remove this side effect or just want to customize fzf's default options, then set export your own `FZF_DEFAULT_OPTS` variable. For example:
-
 ```fish
 set --export FZF_DEFAULT_OPTS +i --height 50% --no-extended
 ```
@@ -171,7 +169,6 @@ Find answers to these questions and more in the [project Wiki](https://github.co
 [bat]: https://github.com/sharkdp/bat
 [build status badge]: https://img.shields.io/github/workflow/status/patrickf1/fzf.fish/CI
 [cd docs]: https://fishshell.com/docs/current/cmds/cd.html
-[conf.d/fzf.fish]: conf.d/fzf.fish
 [custom preview command]: functions/_fzf_preview_file.fish#L7
 [fd]: https://github.com/sharkdp/fd
 [fish]: https://fishshell.com

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Once you've found the `fzf_configure_bindings` command that produces the desired
 
 fzf supports setting default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable. If it is set, fzf implicitly prepends it to the options passed to it on every execution, scripted and interactive.
 
-By default, `fzf.fish` will set a sane `FZF_DEFAULT_OPTS` every time before it executes Fzf. However, If you export your own `FZF_DEFAULT_OPTS` variable, then `fzf.fish` will forgo setting it and yours will be used instead. See [functions/\_fzf_wrapper.fish](functions/_fzf_wrapper.fish) for more details.
+By default, `fzf.fish` will set a sane `FZF_DEFAULT_OPTS` every time before it executes fzf. However, if you export your own `FZF_DEFAULT_OPTS` variable, then `fzf.fish` will forgo setting it and yours will be used instead. See [functions/\_fzf_wrapper.fish](functions/_fzf_wrapper.fish) for more details.
 
 ### Pass fzf options for a specific feature
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Once you've found the `fzf_configure_bindings` command that produces the desired
 
 fzf supports setting default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable. If it is set, fzf implicitly prepends it to the options passed to it on every execution, scripted and interactive.
 
-By default, `fzf.fish` sets a sane `FZF_DEFAULT_OPTS` before it executes Fzf. However, If you export your own `FZF_DEFAULT_OPTS` variable, then `fzf.fish` will forgo setting it and yours will be used instead. See [functions/\_fzf_wrapper.fish](functions/_fzf_wrapper.fish) for more details.
+By default, `fzf.fish` will set a sane `FZF_DEFAULT_OPTS` every time before it executes Fzf. However, If you export your own `FZF_DEFAULT_OPTS` variable, then `fzf.fish` will forgo setting it and yours will be used instead. See [functions/\_fzf_wrapper.fish](functions/_fzf_wrapper.fish) for more details.
 
 ### Pass fzf options for a specific feature
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,7 @@ Once you've found the `fzf_configure_bindings` command that produces the desired
 
 fzf supports setting default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable. If it is set, fzf implicitly prepends it to the options passed to it on every execution, scripted and interactive.
 
-```fish
-set --export FZF_DEFAULT_OPTS +i --height 50% --no-extended
-```
+By default, `fzf.fish` sets a sane `FZF_DEFAULT_OPTS` before it executes Fzf. However, If you export your own `FZF_DEFAULT_OPTS` variable, then `fzf.fish` will forgo setting it and yours will be used instead. See [functions/_fzf_wrapper.fish][] for more details.
 
 ### Pass fzf options for a specific feature
 

--- a/conf.d/fzf.fish
+++ b/conf.d/fzf.fish
@@ -13,19 +13,6 @@ set --global _fzf_search_vars_command '_fzf_search_variables (set --show | psub)
 # Install the default bindings, which are mnemonic and minimally conflict with fish's preset bindings
 fzf_configure_bindings
 
-# If FZF_DEFAULT_OPTS is not set, then set some sane defaults. This also affects fzf outside of this plugin.
-# See https://github.com/junegunn/fzf#environment-variables
-if not set --query FZF_DEFAULT_OPTS
-    # cycle allows jumping between the first and last results, making scrolling faster
-    # layout=reverse lists results top to bottom, mimicking the familiar layouts of git log, history, and env
-    # border makes clear where the fzf window begins and ends
-    # height=90% leaves space to see the current command and some scrollback, maintaining context of work
-    # preview-window=wrap wraps long lines in the preview window, making reading easier
-    # marker=* makes the multi-select marker more distinguishable from the pointer (since both default to >)
-    set --global --export FZF_DEFAULT_OPTS '--cycle --layout=reverse --border --height=90% --preview-window=wrap --marker="*"'
-end
-
-# Doesn't erase FZF_DEFAULT_OPTS because too hard to tell if it was set by the user or by this plugin
 # Doesn't erase autoloaded _fzf_* functions because they are not easily accessible once key bindings are erased
 function _fzf_uninstall --on-event fzf_uninstall
     _fzf_uninstall_bindings

--- a/functions/_fzf_configure_bindings_help.fish
+++ b/functions/_fzf_configure_bindings_help.fish
@@ -21,7 +21,7 @@ DESCRIPTION
     sequences. Rather, consider using fish_key_reader to manually validate them.
 
     In terms of experimentation, fzf_configure_bindings erases any bindings it previously installed
-    before installing new ones so it can be repeatedly invoked in the same fish session without
+    before installing new ones so it can be repeatedly executed in the same fish session without
     problem. Once the desired fzf_configure_bindings command has been found, add it to config.fish
     in order to persist the bindings.
 

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -1,8 +1,4 @@
 function _fzf_search_directory --description "Search the current directory. Replace the current token with the selected file paths."
-    # Make sure that fzf uses fish to execute _fzf_preview_file.
-    # See similar comment in _fzf_search_variables.fish.
-    set --local --export SHELL (command --search fish)
-
     set fd_opts --color=always $fzf_fd_opts
     set fzf_arguments --multi --ansi $fzf_dir_opts
     set token (commandline --current-token)

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -13,10 +13,10 @@ function _fzf_search_directory --description "Search the current directory. Repl
         set --append fd_opts --base-directory=$unescaped_exp_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
         set --prepend fzf_arguments --prompt="$unescaped_exp_token" --preview="_fzf_preview_file $expanded_token{}"
-        set file_paths_selected $unescaped_exp_token(fd $fd_opts 2>/dev/null | fzf $fzf_arguments)
+        set file_paths_selected $unescaped_exp_token(fd $fd_opts 2>/dev/null | _fzf_wrapper $fzf_arguments)
     else
         set --prepend fzf_arguments --query="$unescaped_exp_token" --preview='_fzf_preview_file {}'
-        set file_paths_selected (fd $fd_opts 2>/dev/null | fzf $fzf_arguments)
+        set file_paths_selected (fd $fd_opts 2>/dev/null | _fzf_wrapper $fzf_arguments)
     end
 
 

--- a/functions/_fzf_search_git_log.fish
+++ b/functions/_fzf_search_git_log.fish
@@ -7,7 +7,7 @@ function _fzf_search_git_log --description "Search the output of git log and pre
         set log_fmt_str '%C(bold blue)%h%C(reset) - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
         set selected_log_line (
             git log --color=always --format=format:$log_fmt_str --date=short | \
-            fzf --ansi \
+            _fzf_wrapper --ansi \
                 --tiebreak=index \
                 --preview='git show --color=always {1}' \
                 --query=(commandline --current-token) \

--- a/functions/_fzf_search_git_log.fish
+++ b/functions/_fzf_search_git_log.fish
@@ -2,10 +2,6 @@ function _fzf_search_git_log --description "Search the output of git log and pre
     if not git rev-parse --git-dir >/dev/null 2>&1
         echo '_fzf_search_git_log: Not in a git repository.' >&2
     else
-        # Make sure that fzf uses fish to execute git show.
-        # See similar comment in _fzf_search_variables.fish.
-        set --local --export SHELL (command --search fish)
-
         # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
         # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
         set log_fmt_str '%C(bold blue)%h%C(reset) - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'

--- a/functions/_fzf_search_git_status.fish
+++ b/functions/_fzf_search_git_status.fish
@@ -5,7 +5,7 @@ function _fzf_search_git_status --description "Search the output of git status. 
         set selected_paths (
             # Pass configuration color.status=always to force status to use colors even though output is sent to a pipe
             git -c color.status=always status --short |
-            fzf --ansi \
+            _fzf_wrapper --ansi \
                 --multi \
                 --query=(commandline --current-token) \
                 $fzf_git_status_opts

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -2,10 +2,6 @@ function _fzf_search_history --description "Search command history. Replace the 
     # history merge incorporates history changes from other fish sessions
     builtin history merge
 
-    # Make sure that fzf uses fish so we can run fish_indent.
-    # See similar comment in _fzf_search_variables.fish.
-    set --local --export SHELL (command --search fish)
-
     set command_with_ts (
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S │ " |

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -5,7 +5,7 @@ function _fzf_search_history --description "Search command history. Replace the 
     set command_with_ts (
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S │ " |
-        fzf --read0 \
+        _fzf_wrapper --read0 \
             --tiebreak=index \
             --query=(commandline) \
             # preview current command using fish_ident in a window at the bottom 3 lines tall

--- a/functions/_fzf_search_variables.fish
+++ b/functions/_fzf_search_variables.fish
@@ -9,11 +9,6 @@ function _fzf_search_variables --argument-names set_show_output set_names_output
         return 22 # 22 means invalid argument in POSIX
     end
 
-    # Make sure that fzf uses fish to execute _fzf_extract_var_info, which
-    # is an autoloaded fish function so doesn't exist in other shells.
-    # Use --local so that it does not clobber SHELL outside of this function.
-    set --local --export SHELL (command --search fish)
-
     # Exclude the history variable from being piped into fzf because
     # 1. it's not included in $set_names_output
     # 2. it tends to be a very large value => increases computation time

--- a/functions/_fzf_search_variables.fish
+++ b/functions/_fzf_search_variables.fish
@@ -22,7 +22,7 @@ function _fzf_search_variables --argument-names set_show_output set_names_output
 
     set variable_names_selected (
         printf '%s\n' $all_variable_names |
-        fzf --preview "_fzf_extract_var_info {} $set_show_output" \
+        _fzf_wrapper --preview "_fzf_extract_var_info {} $set_show_output" \
             --multi \
             --query=$cleaned_curr_token \
             $fzf_shell_vars_opts

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -4,5 +4,17 @@ function _fzf_wrapper --description "Prepares some environment variables before 
     # Use --local so that it doesn't clobber SHELL outside of this function.
     set --local --export SHELL (command --search fish)
 
+    # If FZF_DEFAULT_OPTS is not set, then set some sane defaults.
+    # See https://github.com/junegunn/fzf#environment-variables
+    if not set --query FZF_DEFAULT_OPTS
+        # cycle allows jumping between the first and last results, making scrolling faster
+        # layout=reverse lists results top to bottom, mimicking the familiar layouts of git log, history, and env
+        # border makes clear where the fzf window begins and ends
+        # height=90% leaves space to see the current command and some scrollback, maintaining context of work
+        # preview-window=wrap wraps long lines in the preview window, making reading easier
+        # marker=* makes the multi-select marker more distinguishable from the pointer (since both default to >)
+        set --global --export FZF_DEFAULT_OPTS '--cycle --layout=reverse --border --height=90% --preview-window=wrap --marker="*"'
+    end
+
     fzf $argv
 end

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -1,0 +1,8 @@
+function _fzf_wrapper --description "Prepares some environment variables before invoking fzf."
+    # Make sure fzf uses fish to execute preview functions, some of which
+    # are autoloaded so don't exist in other shells.
+    # Use --local so that it doesn't clobber SHELL outside of this function.
+    set --local --export SHELL (command --search fish)
+
+    fzf $argv
+end

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -9,7 +9,7 @@ function _fzf_wrapper --description "Prepares some environment variables before 
     if not set --query FZF_DEFAULT_OPTS
         # cycle allows jumping between the first and last results, making scrolling faster
         # layout=reverse lists results top to bottom, mimicking the familiar layouts of git log, history, and env
-        # border makes clear where the fzf window begins and ends
+        # border shows where the fzf window begins and ends
         # height=90% leaves space to see the current command and some scrollback, maintaining context of work
         # preview-window=wrap wraps long lines in the preview window, making reading easier
         # marker=* makes the multi-select marker more distinguishable from the pointer (since both default to >)

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -13,7 +13,7 @@ function _fzf_wrapper --description "Prepares some environment variables before 
         # height=90% leaves space to see the current command and some scrollback, maintaining context of work
         # preview-window=wrap wraps long lines in the preview window, making reading easier
         # marker=* makes the multi-select marker more distinguishable from the pointer (since both default to >)
-        set --global --export FZF_DEFAULT_OPTS '--cycle --layout=reverse --border --height=90% --preview-window=wrap --marker="*"'
+        set --export FZF_DEFAULT_OPTS '--cycle --layout=reverse --border --height=90% --preview-window=wrap --marker="*"'
     end
 
     fzf $argv

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -1,6 +1,6 @@
-function _fzf_wrapper --description "Prepares some environment variables before invoking fzf."
-    # Make sure fzf uses fish to execute preview functions, some of which
-    # are autoloaded so don't exist in other shells.
+function _fzf_wrapper --description "Prepares some environment variables before executing fzf."
+    # Make sure fzf uses fish to execute preview commands, some of which
+    # are autoloaded fish functions so don't exist in other shells.
     # Use --local so that it doesn't clobber SHELL outside of this function.
     set --local --export SHELL (command --search fish)
 

--- a/tests/wrapper/doesnt_clobber_env.fish
+++ b/tests/wrapper/doesnt_clobber_env.fish
@@ -1,0 +1,5 @@
+set --global --export SHELL /bin/sh
+# don't set FZF_DEFAULT_OPTS so it will set one
+_fzf_wrapper unknownoption 2>/dev/null # pass unknown options so fzf immediately exits
+@test "doesn't clobber SHELL" "$SHELL" = /bin/sh
+@test "doesn't clobber FZF_DEFAULT_OPTS" (set --query FZF_DEFAULT_OPTS) $status -eq 1


### PR DESCRIPTION
Create a wrapper around internal execution of fzf, and in it set `SHELL` and `FZF_DEFAULT_OPTS`. This has three huge advantages:
1. Before `FZF_DEFAULT_OPTS` was set in config.fish. By moving that code into an internal wrapper, we no longer meaningfully dirty the shell environment. This means fewer side-effects as a result of installing this plugin and so feels a lot purer.
2. This eliminates the problem of properly uninstalling the default `FZF_DEFAULT_OPTS` in the uninstall function.
2. We have finally consolidated of the code that forces `SHELL` to be fish.