### PR TITLE
[Search variables] Remove excessive escape for replacement

### DIFF
--- a/functions/_fzf_extract_var_info.fish
+++ b/functions/_fzf_extract_var_info.fish
@@ -11,5 +11,5 @@ function _fzf_extract_var_info --argument-names variable_name set_show_output --
         #   [1]: |value|
         # ...with...
         #   [1] value
-        string replace --regex ": \|(.*)\|" ' \$1'
+        string replace --regex ": \|(.*)\|" ' $1'
 end


### PR DESCRIPTION
This fixes displaying the value of variables in the variable preview.

This change confuses me for the following observations:
escaping the $ inside the regex should never work as intended (as far as I understand), but using fish 3.3.1 the existing code somehow works in the first fish instance I start after deleting the fish_variables file.
The changed code always works for me. 