### PR TITLE
Hide ./ prefix when fd version >= 8.3.0

### DIFF
--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -6,7 +6,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # Remove this logic March '22 iff fd docs document --strip-cwd-prefix
         set --prepend fd_opts --strip-cwd-prefix
     end
-    
+
     set fzf_arguments --multi --ansi $fzf_dir_opts
     set token (commandline --current-token)
     # expand any variables or leading tilde (~) in the token

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -1,5 +1,12 @@
 function _fzf_search_directory --description "Search the current directory. Replace the current token with the selected file paths."
     set fd_opts --color=always $fzf_fd_opts
+    if test (fd --version | string replace --regex --all '[^\d]' '') -ge 830
+        # fd 8.3 prepends ./ to all paths when output is being piped
+        # we don't need this so we hide it by passing --strip-cwd-prefix
+        # TODO remove in a few months and only if fd docs document --strip-cwd-prefix
+        set --prepend fd_opts --strip-cwd-prefix
+    end
+    
     set fzf_arguments --multi --ansi $fzf_dir_opts
     set token (commandline --current-token)
     # expand any variables or leading tilde (~) in the token
@@ -7,11 +14,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
     # unescape token because it's already quoted so backslashes will mess up the path
     set unescaped_exp_token (string unescape -- $expanded_token)
 
-    # Hide ./ prefix when fd version >= 8.3.0
-    # https://github.com/sharkdp/fd/releases/tag/v8.3.0
-    if test (fd --version | string replace --regex --all '[^\d]' '') -ge 830
-        set --prepend fd_opts --strip-cwd-prefix
-    end
+
 
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -1,7 +1,7 @@
 function _fzf_search_directory --description "Search the current directory. Replace the current token with the selected file paths."
     set fd_opts --color=always $fzf_fd_opts
     if test (fd --version | string replace --regex --all '[^\d]' '') -ge 830
-        # fd 8.3 prepends ./ to all paths when output is being piped
+        # fd >= 8.3.0 prepends ./ to all paths when output is being piped
         # we don't need this so we hide it by passing --strip-cwd-prefix
         # Remove this logic March '22 iff fd docs document --strip-cwd-prefix
         set --prepend fd_opts --strip-cwd-prefix

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -3,7 +3,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
     if test (fd --version | string replace --regex --all '[^\d]' '') -ge 830
         # fd 8.3 prepends ./ to all paths when output is being piped
         # we don't need this so we hide it by passing --strip-cwd-prefix
-        # TODO remove March '22 and only if fd docs document --strip-cwd-prefix
+        # Remove this logic March '22 iff fd docs document --strip-cwd-prefix
         set --prepend fd_opts --strip-cwd-prefix
     end
     

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -7,6 +7,12 @@ function _fzf_search_directory --description "Search the current directory. Repl
     # unescape token because it's already quoted so backslashes will mess up the path
     set unescaped_exp_token (string unescape -- $expanded_token)
 
+    # Hide ./ prefix when fd version >= 8.3.0
+    # https://github.com/sharkdp/fd/releases/tag/v8.3.0
+    if test (fd --version | string replace --regex --all '[^\d]' '') -ge 830
+        set --prepend fd_opts --strip-cwd-prefix
+    end
+
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
     if string match --quiet -- "*/" $unescaped_exp_token && test -d "$unescaped_exp_token"

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -14,8 +14,6 @@ function _fzf_search_directory --description "Search the current directory. Repl
     # unescape token because it's already quoted so backslashes will mess up the path
     set unescaped_exp_token (string unescape -- $expanded_token)
 
-
-
     # If the current token is a directory and has a trailing slash,
     # then use it as fd's base directory.
     if string match --quiet -- "*/" $unescaped_exp_token && test -d "$unescaped_exp_token"

--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -3,7 +3,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
     if test (fd --version | string replace --regex --all '[^\d]' '') -ge 830
         # fd 8.3 prepends ./ to all paths when output is being piped
         # we don't need this so we hide it by passing --strip-cwd-prefix
-        # TODO remove in a few months and only if fd docs document --strip-cwd-prefix
+        # TODO remove March '22 and only if fd docs document --strip-cwd-prefix
         set --prepend fd_opts --strip-cwd-prefix
     end
     


### PR DESCRIPTION
[fd 8.3.0](https://github.com/sharkdp/fd/releases/tag/v8.3.0) introduced a `--strip-cwd-prefix` flag to revert a new behavior: `./` prefix is shown when output is not a tty (terminal).

This is what you get in `_fzf_search_directory` without this patch:
<img width="752" alt="截屏2021-11-29 20 06 42" src="https://user-images.githubusercontent.com/44045911/143865481-f9054573-8167-4934-a4fa-1ce3c5a074c5.png">
And with this patch:
<img width="752" alt="截屏2021-11-29 20 06 53" src="https://user-images.githubusercontent.com/44045911/143865501-789e7cb8-867f-4268-bd6c-ceb962fcfbab.png">

