### PR TITLE
Put `preview-window` on bottom in `_fzf_search_processes`

### DIFF
--- a/functions/_fzf_search_processes.fish
+++ b/functions/_fzf_search_processes.fish
@@ -10,6 +10,7 @@ function _fzf_search_processes --description "Search all running processes. Repl
                      # first line outputted by ps is a header, so we need to mark it as so
                      --header-lines=1 \
                      --preview="ps -o '$ps_preview_fmt' -p {1}" \
+                     --preview-window="bottom:4:wrap" \
                      $fzf_processes_opts
     )
 


### PR DESCRIPTION
`ps` outputs in a tabular format, and since the `_fzf_search_processes` function runs `ps` for a single process to generate the preview, the content of the preview is much more "horizontal" (similar to the `_fzf_search_history` function) since it's a single row of information.

This PR specifies that the `preview-window` for `_fzf_search_processes` should be on the bottom, 4 pixels tall, and wrapped. Since the header will always take up the first line, this gives the `COMMAND` 3 lines to wrap (same amount of lines that `_fzf_search_history` gives commands to wrap).

## Before

![Screen Shot 2022-02-24 at 9 50 25 AM](https://user-images.githubusercontent.com/6618434/155558976-2ab6cae1-a451-47a9-a27c-3fefd0174e86.png)

## After

![Screen Shot 2022-02-24 at 9 50 38 AM](https://user-images.githubusercontent.com/6618434/155559000-3522e18f-fc0f-422d-8ac5-aa7e57c94063.png)