### PR TITLE
[Search processes] account for exited processes in preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use `fzf.fish` to interactively find and insert the shell entities listed below 
 
 - **Search input:** the pid and command of all running processes, outputted by `ps`
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd> (`P` for process)
-- **Preview window:** the CPU usage, memory usage, start time, and other information about the process (shown in red if exited)
+- **Preview window:** the CPU usage, memory usage, start time, and other information about the process
 
 _The prompt used in the screencasts was created using [IlanCosman/tide](https://github.com/IlanCosman/tide)._
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Use `fzf.fish` to interactively find and insert the shell entities listed below 
 - **Search input:** all the variable names of the environment currently [in scope][var scope]
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>V</kbd> (`V` for variable)
 - **Preview window:** the scope info and values of the variable
-- `$history` is excluded for technical reasons so use the search command history feature instead to inspect it
+- `$history` is excluded for technical reasons so use the [search command history](#a-previously-run-command) feature instead to inspect it
 
 ### Process ids
 
@@ -64,7 +64,7 @@ Use `fzf.fish` to interactively find and insert the shell entities listed below 
 
 - **Search input:** the pid and command of all running processes, outputted by `ps`
 - **Key binding and mnemonic:** <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd> (`P` for process)
-- **Preview window:** the CPU usage, memory usage, start time, and other information about the process
+- **Preview window:** the CPU usage, memory usage, start time, and other information about the process (shown in red if exited)
 
 _The prompt used in the screencasts was created using [IlanCosman/tide](https://github.com/IlanCosman/tide)._
 

--- a/functions/_fzf_search_processes.fish
+++ b/functions/_fzf_search_processes.fish
@@ -9,8 +9,8 @@ function _fzf_search_processes --description "Search all running processes. Repl
                      --ansi \
                      # first line outputted by ps is a header, so we need to mark it as so
                      --header-lines=1 \
-                     # 40 is the length from "PID" to "COMMAND" in the header "PID PARENT USER  %CPU RSS_IN_KB START_TIME COMMAND"
-                     --preview="ps -o '$ps_preview_fmt' -p {1} || begin; set_color red; echo {1}(string repeat --count 40 ' '){2..}; end" \
+                     # ps uses exit code 1 if the process was not found, in which case we show an error explaining so
+                     --preview="ps -o '$ps_preview_fmt' -p {1} || echo 'Cannot preview {1} because it exited.'" \
                      --preview-window="bottom:4:wrap" \
                      $fzf_processes_opts
     )

--- a/functions/_fzf_search_processes.fish
+++ b/functions/_fzf_search_processes.fish
@@ -9,7 +9,7 @@ function _fzf_search_processes --description "Search all running processes. Repl
                      --ansi \
                      # first line outputted by ps is a header, so we need to mark it as so
                      --header-lines=1 \
-                     --preview="ps -o '$ps_preview_fmt' -p {1}" \
+                     --preview="ps -o '$ps_preview_fmt' -p {1} || begin; set_color red; echo {1}(string repeat --count 40 ' '){2..}; end" \
                      --preview-window="bottom:4:wrap" \
                      $fzf_processes_opts
     )

--- a/functions/_fzf_search_processes.fish
+++ b/functions/_fzf_search_processes.fish
@@ -9,6 +9,7 @@ function _fzf_search_processes --description "Search all running processes. Repl
                      --ansi \
                      # first line outputted by ps is a header, so we need to mark it as so
                      --header-lines=1 \
+                     # 40 is the length from "PID" to "COMMAND" in the header "PID PARENT USER  %CPU RSS_IN_KB START_TIME COMMAND"
                      --preview="ps -o '$ps_preview_fmt' -p {1} || begin; set_color red; echo {1}(string repeat --count 40 ' '){2..}; end" \
                      --preview-window="bottom:4:wrap" \
                      $fzf_processes_opts

--- a/functions/_fzf_search_processes.fish
+++ b/functions/_fzf_search_processes.fish
@@ -9,7 +9,7 @@ function _fzf_search_processes --description "Search all running processes. Repl
                      --ansi \
                      # first line outputted by ps is a header, so we need to mark it as so
                      --header-lines=1 \
-                     # ps uses exit code 1 if the process was not found, in which case we show an error explaining so
+                     # ps uses exit code 1 if the process was not found, in which case show an message explaining so
                      --preview="ps -o '$ps_preview_fmt' -p {1} || echo 'Cannot preview {1} because it exited.'" \
                      --preview-window="bottom:4:wrap" \
                      $fzf_processes_opts


### PR DESCRIPTION
First, thanks for your effort in getting the process search feature in! I saw the mention but unfortunately don't have the time to chime in.

I was not satisfied as you did, and made some local changes to fzf.fish. It was until #227 got merged that I realized I never submitted those patches (yes, I have been putting the preview window on the bottom for the longest time).

So here is the change that I really want to upstream: mark exited process as red.

<img width="672" alt="Screen Shot 2022-02-28 at 19 59 59" src="https://user-images.githubusercontent.com/44045911/155979955-08eaefc4-d9fd-48e6-9b4b-56f483c629b3.png">

Since [the preview is provided by a second `ps`](https://github.com/PatrickF1/fzf.fish/blob/a033d17b6d0288400b34c69911822e879b7d98bd/functions/_fzf_search_processes.fish#L12), the selected process may have already exited and all we get is a confusing header.

_Where is that process I want to look at?_

Even if it exited, the full process name along with its parameter is still useful, but without a functioning preview, the only chance you see it in whole is to have a super-duper wide display (does this even exist?)

No more. The process info is right in fzf itself and we just need to instruct fzf to use _that_ instead.