### PR TITLE
[Search git status] fix extra quotes from spaced file paths

### DIFF
--- a/functions/_fzf_search_git_status.fish
+++ b/functions/_fzf_search_git_status.fish
@@ -25,7 +25,7 @@ function _fzf_search_git_status --description "Search the output of git status. 
                 end
             end
 
-            commandline --current-token --replace -- (string escape -- $cleaned_paths | string join ' ')
+            commandline --current-token --replace -- (string join ' ' $cleaned_paths)
         end
     end
 

--- a/tests/search_git_status/outputs_right_paths.fish
+++ b/tests/search_git_status/outputs_right_paths.fish
@@ -1,10 +1,11 @@
-set files "filename_with_*.txt" "filename with space.csv"
+set files "filename_with_*.txt" "filename with space.csv" tests/_resources/nestedfilename
 touch $files
 mock commandline \* ""
 mock commandline "--current-token --replace --" "echo \$argv"
 set --export --append FZF_DEFAULT_OPTS "--filter='filename'"
+
 set actual (_fzf_search_git_status)
-test $actual = 'filename_with_*.txt "filename with space.csv"'
+test $actual = 'filename_with_*.txt "filename with space.csv" tests/_resources/nestedfilename'
 @test "correct paths found in output" $status -eq 0
 
 rm $files

--- a/tests/search_git_status/outputs_right_paths.fish
+++ b/tests/search_git_status/outputs_right_paths.fish
@@ -4,7 +4,7 @@ mock commandline \* ""
 mock commandline "--current-token --replace --" "echo \$argv"
 set --export --append FZF_DEFAULT_OPTS "--filter='filename'"
 set actual (_fzf_search_git_status)
-string match $files[1] --entire -q $actual && string match --entire -q $files[2] $actual
+test $actual = 'filename_with_*.txt "filename with space.csv"'
 @test "correct paths found in output" $status -eq 0
 
 rm $files

--- a/tests/wrapper/doesnt_clobber_env.fish
+++ b/tests/wrapper/doesnt_clobber_env.fish
@@ -1,5 +1,6 @@
 set --global --export SHELL /bin/sh
-# don't set FZF_DEFAULT_OPTS so it will set one
+# erase FZF_DEFAULT_OPTS so that one will be set by the wrapper function
+set --erase FZF_DEFAULT_OPTS
 _fzf_wrapper unknownoption 2>/dev/null # pass unknown options so fzf immediately exits
 @test "doesn't clobber SHELL" "$SHELL" = /bin/sh
 @test "doesn't clobber FZF_DEFAULT_OPTS" (set --query FZF_DEFAULT_OPTS) $status -eq 1


### PR DESCRIPTION
This fixes a bug where file paths outputted by search git status include an extra layer of single quotes if the path includes a space. Turns out this is because we string escape all our paths before writing them to the command line but git status already string escapes paths with spaces.

Fixes #220 