### PR TITLE
[Search directory] Prevent duplicate / when fd version >= 8.4.0

### DIFF
--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -31,7 +31,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
         # Then, the user only needs to hit Enter once more to cd into that directory.
         if test (count $file_paths_selected) = 1
             set commandline_tokens (commandline --tokenize)
-            if test "$commandline_tokens" = "$token" -a -d "$file_paths_selected"
+            if test "$commandline_tokens" = "$token" -a -d "$file_paths_selected" -a (fd --version | string replace --regex --all '[^\d]' '') -lt 840
                 set file_paths_selected $file_paths_selected/
             end
         end


### PR DESCRIPTION
fd 8.4.0 just released with this (long-awaited?) change:

> [Directories are now printed with an additional path separator at the end](https://github.com/sharkdp/fd/releases/tag/v8.4.0#:~:text=Directories%20are%20now%20printed%20with%20an%20additional%20path%20separator%20at%20the%20end)

This is different from how it is handled in fzf.fish, where directories are only appended a slash under _strict_ conditions, so strict it may look like a bug. I'm saying this because I kinda think fzf.fish should have handled it like fd from the beginning.

Now onto the issue. Most programs treat duplicate slashes as one and works as intended, but it certainly does not look good. There are several possible solutions:

- **Don't do our thing if fd version is >= 8.4.0.** Easiest one, also how this PR is done currently. Just one trivial problem: people may notice a slight difference of _fzf.fish_ when they bump _fd_, not intuitive.
- **Follow fd and append slashes to directories all the time.** May not worth the effort as the code are going to be dropped when most users upgraded to newer fd version.
- **Go out of our way and drop all slashes from fd.** In other words, keep fzf.fish's behavior consistent across fd versions. This solution is here only for completeness.

I'm not sure about how to revise the README, maybe just leave it as is.