### PR TITLE
[Search history] don't merge history when in private mode

### DIFF
--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -1,5 +1,6 @@
 function _fzf_search_history --description "Search command history. Replace the command line with the selected command."
     # history merge incorporates history changes from other fish sessions
+    # skip merging in private mode as it clears current session history
     if test "$fish_private_mode" != 1
         builtin history merge
     end

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -1,7 +1,7 @@
 function _fzf_search_history --description "Search command history. Replace the command line with the selected command."
     # history merge incorporates history changes from other fish sessions
     # skip merging in private mode as it clears current session history
-    if test "$fish_private_mode" != 1
+    if test -n "$fish_provate_mode"
         builtin history merge
     end
 

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -1,6 +1,8 @@
 function _fzf_search_history --description "Search command history. Replace the command line with the selected command."
     # history merge incorporates history changes from other fish sessions
-    builtin history merge
+    if test "$fish_private_mode" != 1
+        builtin history merge
+    end
 
     set command_with_ts (
         # Reference https://devhints.io/strftime to understand strftime format symbols


### PR DESCRIPTION
Calling `history merge` in private mode (`fish --private`) **clears** the session history. So if you execute the search history function while in private mode, there is no history to search.