### PR TITLE
[Search history] simplify logic into pipeline

### DIFF
--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -5,10 +5,8 @@ function _fzf_search_history --description "Search command history. Replace the 
         builtin history merge
     end
 
-    set ts_regex '^\d\d-\d\d \d\d:\d\d:\d\d │ '
-
+    # Delinate commands throughout pipeline using null rather than newlines because commands can be multi-line
     set commands_selected (
-        # Delinate commands using null rather than newlines because commands can be multi-line
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S │ " |
         _fzf_wrapper --read0 \
@@ -16,13 +14,12 @@ function _fzf_search_history --description "Search command history. Replace the 
             --multi \
             --tiebreak=index \
             --query=(commandline) \
-            # preview current command using fish_ident in a window at the bottom 3 lines tall
             --preview="echo -- {4..} | fish_indent --ansi" \
             --preview-window="bottom:3:wrap" \
             $fzf_history_opts |
         string split0 |
-        # remove timestamps from commands before putting them into command line
-        string replace --regex $ts_regex ''
+        # remove timestamps from commands selected
+        string replace --regex '^\d\d-\d\d \d\d:\d\d:\d\d │ ' ''
     )
 
     if test $status -eq 0

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -5,7 +5,9 @@ function _fzf_search_history --description "Search command history. Replace the 
         builtin history merge
     end
 
-    set commands_with_ts (
+    set ts_regex '^\d\d-\d\d \d\d:\d\d:\d\d │ '
+
+    set commands_selected (
         # Delinate commands using null rather than newlines because commands can be multi-line
         # Reference https://devhints.io/strftime to understand strftime format symbols
         builtin history --null --show-time="%m-%d %H:%M:%S │ " |
@@ -18,15 +20,12 @@ function _fzf_search_history --description "Search command history. Replace the 
             --preview="echo -- {4..} | fish_indent --ansi" \
             --preview-window="bottom:3:wrap" \
             $fzf_history_opts |
-        string split0
+        string split0 |
+        # remove timestamps from commands before putting them into command line
+        string replace --regex $ts_regex ''
     )
 
     if test $status -eq 0
-        set commands_selected
-        # remove timestamps from commands before putting them into command line
-        for c in $commands_with_ts
-            set --append commands_selected (string split --max 1 " │ " $c)[2]
-        end
         commandline --replace -- $commands_selected
     end
 


### PR DESCRIPTION
A small flaw with https://github.com/PatrickF1/fzf.fish/pull/252 was that it didn't preserve the boundaries between commands and so at the end, it had to check each line of output for the timestamps and remove them. Not only was that it inefficient and a little hard to understand, it could potentially result in a bug if a command ever included a line that began with "$datetimestring | ". 

A better solution is to keep each command selected as an individual argument throughout the entire pipeline by delineating them with nulls, which is thankfully supported by fzf and fish string utils. Additionally, I realized the logic of stripping out the timestamps could be elegantly integrated into the [pipeline](https://en.wikipedia.org/wiki/Pipeline_(Unix)).