### PR TITLE
Add a "grep directory" keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ First, install a proper version of these CLI dependencies:
 | [fzf][]  | 0.27.2                   | fuzzy finder that powers this plugin           |
 | [fd][]   | 8.3.0                    | faster and more colorful alternative to `find` |
 | [bat][]  | 0.16.0                   | smarter `cat` with syntax highlighting         |
+| [rg][]   | (optional)               | faster and more powerful alternative to `grep` |
 
-The search directory feature uses [fd][] and [bat][] to list and preview files. If your package manager [doesn't install them as `fd` and `bat`](https://github.com/PatrickF1/fzf.fish/wiki/Troubleshooting#search-directory-feature-does-not-work) respectively, then you can symlink them to those names.
+The search directory feature uses [fd][] and [bat][] to list and preview files, and grep directory uses [rg][]. If your package manager [doesn't install them as `fd`, `bat`, or `rg`](https://github.com/PatrickF1/fzf.fish/wiki/Troubleshooting#search-directory-feature-does-not-work) respectively, then you can symlink them to those names.
 
 Next, install this plugin with [Fisher][].
 
@@ -120,6 +121,7 @@ The following variables can store custom options that will be passed to fzf by t
 | Search command history | `fzf_history_opts`    |
 | Search shell variables | `fzf_shell_vars_opts` |
 | Search processes       | `fzf_processes_opts`  |
+| Grep directory         | `fzf_grep_opts`       |
 
 They are always appended last to fzf's argument list. Because fzf uses the option appearing last when options conflict, your custom options can override hardcoded options. Custom fzf options unlocks a variety of possibilities in customizing and augmenting each feature such as:
 
@@ -161,6 +163,16 @@ set fzf_fd_opts --hidden --exclude=.git
 
 <a id='fd-gi'></a>By default, `fd` hides files listed in `.gitignore`. You can disable this behavior by adding the `--no-ignore` flag to `fzf_fd_opts`.
 
+### Change grep behavior
+
+Grep directory uses `rg` to find matching files in the current directory. To pass custom options to `rg` when it is executed, set the `fzf_rg_opts` variable. For example, to use literal strings instead of regexp, put this into your `config.fish:`:
+
+```fish
+set fzf_rg_opts --fixed-strings
+```
+
+<a id='rg-gi'></a>By default, `rg` hides files listed in `.gitignore`. You can disable this behavior by adding the `--no-ignore` flag to `fzf_rg_opts`.
+
 ## Further reading
 
 Find answers to these questions and more in the [project Wiki](https://github.com/PatrickF1/fzf.fish/wiki):
@@ -178,6 +190,7 @@ Find answers to these questions and more in the [project Wiki](https://github.co
 [fish]: https://fishshell.com
 [fisher]: https://github.com/jorgebucaran/fisher
 [fzf]: https://github.com/junegunn/fzf
+[rg]: https://github.com/BurntSushi/ripgrep
 [latest release badge]: https://img.shields.io/github/v/release/patrickf1/fzf.fish
 [universal variable]: https://fishshell.com/docs/current/#more-on-universal-variables
 [var scope]: https://fishshell.com/docs/current/#variable-scope

--- a/functions/_fzf_configure_bindings_help.fish
+++ b/functions/_fzf_configure_bindings_help.fish
@@ -13,6 +13,7 @@ DESCRIPTION
         Search history     |  Ctrl+R     (R for reverse)   |  --history
         Search variables   |  Ctrl+V     (V for variable)  |  --variables
         Search processes   |  Ctrl+Alt+P (P for process)   |  --processes
+        Grep directory     |  Ctrl+G     (G for grep)      |  --grep
     An option with a key sequence value overrides the binding for its feature, while an option
     without a value disables the binding. A feature that is not customized retains its default
     menomonic binding specified above. Key bindings are installed for default and insert modes.
@@ -38,6 +39,6 @@ EXAMPLES
     Alternative style of disabling search history
         \$ fzf_configure_bindings --history=
     An agglomeration of all the options
-        \$ fzf_configure_bindings --git_status=\cg --history=\ch --variables --directory --git_log
+        \$ fzf_configure_bindings --git_status=\cg --history=\ch --variables --directory --git_log --grep
 "
 end

--- a/functions/_fzf_grep_directory.fish
+++ b/functions/_fzf_grep_directory.fish
@@ -1,0 +1,19 @@
+function _fzf_grep_directory --description "Grep the current directory. Replace the current token with the selected file paths."
+    set rg_opts --no-heading --line-number --color=always $fzf_rg_opts --
+
+    set fzf_arguments --multi --ansi --phony --delimiter=':' $fzf_grep_opts
+    set token (commandline --current-token)
+    # expand any variables or leading tilde (~) in the token
+    set expanded_token (eval echo -- $token)
+    # unescape token because it's already quoted so backslashes will mess up the path
+    set unescaped_exp_token (string unescape -- $expanded_token)
+
+    set --prepend fzf_arguments --prompt="rg > " --query="$unescaped_exp_token" --preview='_fzf_preview_file {1}' --bind="change:reload:rg $rg_opts 2>/dev/null {q}"
+    set file_paths_selected (rg $rg_opts 2>/dev/null | _fzf_wrapper $fzf_arguments | cut -d: -f1)
+
+    if test $status -eq 0
+        commandline --current-token --replace -- (string escape -- $file_paths_selected | string join ' ')
+    end
+
+    commandline --function repaint
+end

--- a/functions/_fzf_grep_directory.fish
+++ b/functions/_fzf_grep_directory.fish
@@ -1,7 +1,7 @@
 function _fzf_grep_directory --description "Grep the current directory. Replace the current token with the selected file paths."
     set rg_opts --no-heading --line-number --color=always $fzf_rg_opts --
 
-    set fzf_arguments --multi --ansi --phony --delimiter=':' $fzf_grep_opts
+    set fzf_arguments --multi --ansi --phony --delimiter=':' --preview-window='+{2}-/2' $fzf_grep_opts
     set token (commandline --current-token)
     # expand any variables or leading tilde (~) in the token
     set expanded_token (eval echo -- $token)

--- a/functions/_fzf_preview_file.fish
+++ b/functions/_fzf_preview_file.fish
@@ -1,4 +1,4 @@
-# helper function for _fzf_search_directory and _fzf_search_git_status
+# helper function for _fzf_search_directory, _fzf_grep_directory, and _fzf_search_git_status
 function _fzf_preview_file --description "Print a preview for the given file based on its file type."
     # because there's no way to guarantee that _fzf_search_directory passes the path to _fzf_preview_file
     # as one argument, we collect all the arguments into one single variable and treat that as the path

--- a/functions/fzf_configure_bindings.fish
+++ b/functions/fzf_configure_bindings.fish
@@ -4,7 +4,7 @@ function fzf_configure_bindings --description "Installs the default key bindings
     # no need to install bindings if not in interactive mode or running tests
     status is-interactive || test "$CI" = true; or return
 
-    set options_spec h/help 'directory=?' 'git_log=?' 'git_status=?' 'history=?' 'variables=?' 'processes=?'
+    set options_spec h/help 'directory=?' 'git_log=?' 'git_status=?' 'history=?' 'variables=?' 'processes=?' 'grep=?'
     argparse --max-args=0 --ignore-unknown $options_spec -- $argv 2>/dev/null
     if test $status -ne 0
         echo "Invalid option or a positional argument was provided." >&2
@@ -15,14 +15,15 @@ function fzf_configure_bindings --description "Installs the default key bindings
         return
     else
         # Initialize with default key sequences and then override or disable them based on flags
-        # index 1 = directory, 2 = git_log, 3 = git_status, 4 = history, 5 = variables, 6 = processes
-        set key_sequences \e\cf \e\cl \e\cs \cr \cv \e\cp # \c = control, \e = escape
+        # index 1 = directory, 2 = git_log, 3 = git_status, 4 = history, 5 = variables, 6 = processes, 7 = grep
+        set key_sequences \e\cf \e\cl \e\cs \cr \cv \e\cp \cg # \c = control, \e = escape
         set --query _flag_directory && set key_sequences[1] "$_flag_directory"
         set --query _flag_git_log && set key_sequences[2] "$_flag_git_log"
         set --query _flag_git_status && set key_sequences[3] "$_flag_git_status"
         set --query _flag_history && set key_sequences[4] "$_flag_history"
         set --query _flag_variables && set key_sequences[5] "$_flag_variables"
         set --query _flag_processes && set key_sequences[6] "$_flag_processes"
+        set --query _flag_grep && set key_sequences[7] "$_flag_grep"
 
         # If fzf bindings already exists, uninstall it first for a clean slate
         if functions --query _fzf_uninstall_bindings
@@ -36,6 +37,7 @@ function fzf_configure_bindings --description "Installs the default key bindings
             test -n $key_sequences[4] && bind --mode $mode $key_sequences[4] _fzf_search_history
             test -n $key_sequences[5] && bind --mode $mode $key_sequences[5] "$_fzf_search_vars_command"
             test -n $key_sequences[6] && bind --mode $mode $key_sequences[6] _fzf_search_processes
+            test -n $key_sequences[7] && bind --mode $mode $key_sequences[7] _fzf_grep_directory
         end
 
         function _fzf_uninstall_bindings --inherit-variable key_sequences

--- a/tests/configure_bindings/key_sequences.fish
+++ b/tests/configure_bindings/key_sequences.fish
@@ -7,13 +7,15 @@ end
 @test "default binding for git status works" (binding_contains_func \e\cs _fzf_search_git_status) $status -eq 0
 @test "default binding for history works" (binding_contains_func \cr _fzf_search_history) $status -eq 0
 @test "default binding for variables works" (binding_contains_func \cv $_fzf_search_vars_command) $status -eq 0
+@test "default binding for grep works" (binding_contains_func \cg _fzf_grep_directory) $status -eq 0
 
-fzf_configure_bindings --directory=\ca --git_log=\cb --git_status=\cc --history=\cd --variables=\ce
+fzf_configure_bindings --directory=\ca --git_log=\cb --git_status=\cc --history=\cd --variables=\ce --grep=\cf
 @test "can override the default binding for directory" (binding_contains_func \ca _fzf_search_directory) $status -eq 0
 @test "can override the default binding for git log" (binding_contains_func \cb _fzf_search_git_log) $status -eq 0
 @test "can override the default binding for git status" (binding_contains_func \cc _fzf_search_git_status) $status -eq 0
 @test "can override the default binding for history" (binding_contains_func \cd _fzf_search_history) $status -eq 0
 @test "can override the default binding for variables" (binding_contains_func \ce $_fzf_search_vars_command) $status -eq 0
+@test "can override the default binding for grep" (binding_contains_func \cf _fzf_grep_directory) $status -eq 0
 
 bind --mode insert \ca >/dev/null && bind --mode insert \ce >/dev/null
 @test "installs bindings for insert mode" $status -eq 0


### PR DESCRIPTION
This PR adds a new kind of search: grep directory. It's similar to "search directory" but instead of fuzzy-matching file _names_, grep directory does regex-matching on file _content_, powered by `rg`. The default hotkey is ctrl-g.

Here's what it looks like, and one example of why I think it's cool.

![grep-directories](https://user-images.githubusercontent.com/45430/187093713-c8b163d7-2d7d-4116-b136-bebf8e575cf6.gif)

There's a few minor shortcomings that I left out for now to avoid complicating the code. If you think this feature is worthy of inclusion, I'd be happy to give any or all of these a shot!

* This hardcodes `rg`, and so there's no way to switch to `ag`, or `grep -r`.
* If you hit the ctrl-g hotkey with an incomplete token in the buffer, we unconditionally pass that along to `rg` as the initial regex. We could be a little more nuanced. fzf.fish's directory search checks if the input ends with a slash and is a directory, and if so, sets that as the base directory for `fzf`'s input. I think that'd be a good fit here too.
* Running `rg` with no regular expression shows a list of empty results. We can probably do something better than that, but I'm not sure what. (Maybe default to showing all lines when user input is empty, to better match the "filtering" affordance)
* ~The preview window just shows the top of the file. We should automatically scroll to the matching line.~ _edit: Implemented!_
* The preview window should highlight the matching line. To do so we need to thread `--highlight-line {2}` from `_fzf_grep_directory` into `bat`. The blocker here is `_fzf_preview_file`'s comment of "we collect all the arguments into one single [path] variable". (I temporarily hacked in support for highlighting the matching line in the preview video above, but it's not shippable.)

Anyway, thanks for fzf.fish! Let me know if there's anything you'd like me to improve on here.