### PR TITLE
fix homebrew missing in CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           plugins: jorgebucaran/fishtape ilancosman/clownfish $GITHUB_WORKSPACE
 
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: Install fzf and fd
         run: brew install fzf fd
 


### PR DESCRIPTION
homebrew was removed from Ubuntu images in https://github.com/actions/runner-images/issues/6283