### PR TITLE
Replace gifs in readme with one demo video and screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 📁 Search Directory
 
-![gif directory](../assets/directory.gif)
+![gif directory](../assets/directory.png)
 
 - **Fzf input:** recursive listing of current directory's non-hidden files
 - **Output:** relative paths of selected files
@@ -29,7 +29,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 🪵 Search Git Log
 
-![gif git log](../assets/git_log.gif)
+![gif git log](../assets/git_log.png)
 
 - **Fzf input:** the current repository's formatted `git log`
 - **Output:** hashes of selected commits
@@ -38,7 +38,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 📝 Search Git Status
 
-![gif git status](../assets/git_status.gif)
+![gif git status](../assets/git_status.png)
 
 - **Fzf input:** the current repository's `git status`
 - **Output:** relative paths of selected lines
@@ -47,7 +47,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 📜 Search History
 
-![gif command history](../assets/command_history.gif)
+![gif command history](../assets/history.png)
 
 - **Fzf input:** Fish's command history
 - **Output:** selected commands
@@ -56,7 +56,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 🖥️ Search Processes
 
-![gif processes](../assets/processes.gif)
+![gif processes](../assets/processes.png)
 
 - **Fzf input:** the pid and command of all running processes, outputted by `ps`
 - **Output:** pids of selected processes
@@ -65,7 +65,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 💲 Search Variables
 
-![gif shell variables](../assets/shell_variables.gif)
+![gif shell variables](../assets/variables.png)
 
 - **Fzf input:** all the shell variables currently [in scope][var scope]
 - **Output:** selected shell variables

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 
 Augment your [Fish][] command line with mnemonic key bindings to efficiently find what you need using [fzf][].
 
-![demo.gif](../assets/demo.mp4)
+
+
+https://user-images.githubusercontent.com/1967248/197269229-6bfa8d1a-7acf-44e0-93e8-5245c71da1f1.mp4
+
+
 
 ## Search commands
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@
 
 Augment your [Fish][] command line with mnemonic key bindings to efficiently find what you need using [fzf][].
 
-
 https://user-images.githubusercontent.com/1967248/197308919-51d04602-2d5f-46aa-a96e-6cf1617e3067.mov
-
-
 
 ## Search commands
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,7 @@
 Augment your [Fish][] command line with mnemonic key bindings to efficiently find what you need using [fzf][].
 
 
-
-
-
-https://user-images.githubusercontent.com/1967248/197308696-2feddbc9-79a4-492c-a12e-99236dba0194.mov
-
+https://user-images.githubusercontent.com/1967248/197308919-51d04602-2d5f-46aa-a96e-6cf1617e3067.mov
 
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Augment your [Fish][] command line with mnemonic key bindings to efficiently find what you need using [fzf][].
 
+![demo.gif](../assets/demo.gif)
+
 ## Search commands
 
 Use `fzf.fish` to interactively find and insert file paths, git commit hashes, and other entities into your command line. <kbd>Tab</kbd> to select multiple entries. If you trigger a search while your cursor is on a word, that word will be used to seed the fzf query and will be replaced by your selection. All searches include a preview of the entity hovered over so you can seamlessly decide if it's what you're looking for.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Augment your [Fish][] command line with mnemonic key bindings to efficiently find what you need using [fzf][].
 
-![demo.gif](../assets/demo.gif)
+![demo.gif](../assets/demo.mp4)
 
 ## Search commands
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 📁 Search Directory
 
-![gif directory](../assets/directory.png)
+![Search Directory example](../assets/directory.png)
 
 - **Fzf input:** recursive listing of current directory's non-hidden files
 - **Output:** relative paths of selected files
@@ -29,7 +29,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 🪵 Search Git Log
 
-![gif git log](../assets/git_log.png)
+![Search Git Log example](../assets/git_log.png)
 
 - **Fzf input:** the current repository's formatted `git log`
 - **Output:** hashes of selected commits
@@ -38,7 +38,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 📝 Search Git Status
 
-![gif git status](../assets/git_status.png)
+![Search Git Status example](../assets/git_status.png)
 
 - **Fzf input:** the current repository's `git status`
 - **Output:** relative paths of selected lines
@@ -47,7 +47,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 📜 Search History
 
-![gif command history](../assets/history.png)
+![Search History example](../assets/history.png)
 
 - **Fzf input:** Fish's command history
 - **Output:** selected commands
@@ -56,7 +56,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 🖥️ Search Processes
 
-![gif processes](../assets/processes.png)
+![Search Processes example](../assets/processes.png)
 
 - **Fzf input:** the pid and command of all running processes, outputted by `ps`
 - **Output:** pids of selected processes
@@ -65,7 +65,7 @@ Use `fzf.fish` to interactively find and insert file paths, git commit hashes, a
 
 ### 💲 Search Variables
 
-![gif shell variables](../assets/variables.png)
+![Search Variables example](../assets/variables.png)
 
 - **Fzf input:** all the shell variables currently [in scope][var scope]
 - **Output:** selected shell variables

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Augment your [Fish][] command line with mnemonic key bindings to efficiently fin
 
 
 
-https://user-images.githubusercontent.com/1967248/197269229-6bfa8d1a-7acf-44e0-93e8-5245c71da1f1.mp4
+
+
+https://user-images.githubusercontent.com/1967248/197308696-2feddbc9-79a4-492c-a12e-99236dba0194.mov
+
 
 
 


### PR DESCRIPTION
Cons of gifs
- can't pause or rewind to catch the details you missed
- continually plays so can be distracting
- very tedious to record and update every time fzf.fish's UI changes
- they all look the same at the beginning with an empty command line, so hard to distinguish as you scroll through
- requires users to patiently wait for it to completely loop to see the preview functionality, which is what is most eye catching

Solution
- GitHub recently released video upload! https://github.blog/2021-05-13-video-uploads-available-github
- one demo video edited to show key bindings at the top showcasing the features that can the user can pause, rewind, seek 
- screenshots below each feature that statically present each command's most eye catching preview functionality