### PR TITLE
Make instructions to open file in editor clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,14 @@ The following variables can store custom options that will be passed to fzf by t
 They are appended last to fzf's options list. Because fzf uses the last instance of an option if it is specified multiple times, custom options will always take precedence. Custom fzf options unlock a variety of customizations and augmentations such as:
 
 - add [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) within fzf to operate on the selected line:
-  - [open file in Vim](https://github.com/junegunn/fzf/issues/1360)
+  - [open file in in your `$EDITOR`](https://github.com/junegunn/fzf/issues/1360):
+    ```fish
+      # set -gx $EDITOR "nvim" # or "vim", or "code", etc.
+      
+      # Ctrl-o will open the selected file/directory in your editor of choice.
+      set fzf_dir_opts --bind "ctrl-o:execute($EDITOR {} &> /dev/tty)"
+
+    ```
   - [preview image files](https://gitter.im/junegunn/fzf?at=5947962ef6a78eab48620792)
   - git reset file
 - adjust the preview command or window

--- a/README.md
+++ b/README.md
@@ -130,15 +130,19 @@ The following variables can store custom options that will be passed to fzf by t
 They are appended last to fzf's options list. Because fzf uses the last instance of an option if it is specified multiple times, custom options will always take precedence. Custom fzf options unlock a variety of customizations and augmentations such as:
 
 - add [key bindings](https://www.mankier.com/1/fzf#Key/Event_Bindings) within fzf to operate on the selected line:
+
   - [open file in in your `$EDITOR`](https://github.com/junegunn/fzf/issues/1360):
+
     ```fish
       # set -gx $EDITOR "nvim" # or "vim", or "code", etc.
 
       # Ctrl-o will open the selected file/directory in your editor of choice.
       set fzf_dir_opts --bind "ctrl-o:execute($EDITOR {} &> /dev/tty)"
     ```
+
   - [preview image files](https://gitter.im/junegunn/fzf?at=5947962ef6a78eab48620792)
   - git reset file
+
 - adjust the preview command or window
 - [re-populate fzf's input list on demand](https://github.com/junegunn/fzf/issues/1750)
 - change the [search mode](https://github.com/junegunn/fzf#search-syntax)

--- a/README.md
+++ b/README.md
@@ -133,10 +133,9 @@ They are appended last to fzf's options list. Because fzf uses the last instance
   - [open file in in your `$EDITOR`](https://github.com/junegunn/fzf/issues/1360):
     ```fish
       # set -gx $EDITOR "nvim" # or "vim", or "code", etc.
-      
+
       # Ctrl-o will open the selected file/directory in your editor of choice.
       set fzf_dir_opts --bind "ctrl-o:execute($EDITOR {} &> /dev/tty)"
-
     ```
   - [preview image files](https://gitter.im/junegunn/fzf?at=5947962ef6a78eab48620792)
   - git reset file


### PR DESCRIPTION
## Description

It took me a while to understand how to actually set up a binding to open the selected file from the linked issue in the readme, so I thought it'd be clearer to show an example with the actual code that will do it.
