### PR TITLE
[Search Directory] Ensure unaliased fd is called

### DIFF
--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -33,7 +33,7 @@ function _fzf_search_directory --description "Search the current directory. Repl
         if test (count $file_paths_selected) = 1
             set commandline_tokens (commandline --tokenize)
             if test "$commandline_tokens" = "$token" -a -d "$file_paths_selected" \
-                    -a (fd --version | string replace --regex --all '[^\d]' '') -lt 840
+                    -a (command fd --version | string replace --regex --all '[^\d]' '') -lt 840
                 set file_paths_selected $file_paths_selected/
             end
         end


### PR DESCRIPTION
If fd is aliased, Search Directory will hang until fd finishes executing. This is because fish functions buffer. Resolves #281.