### PR TITLE
feat: allow configuring FZF colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ fzf supports global default options via the [FZF_DEFAULT_OPTS](https://github.co
 
 `fzf.fish` locally sets [a sane `FZF_DEFAULT_OPTS` whenever it executes fzf](functions/_fzf_wrapper.fish). If you export your own `FZF_DEFAULT_OPTS`, then yours will be used instead.
 
+### Customize FZF colors
+
+To customize FZF colors, use `fzf_fish_colors` environment variable. If you do not set your own `FZF_DEFAULT_OPTS`, `fzf.fish` will set `$fzf_fish_colors` colors as FZF's colors. For example, `set -x fzf_fish_colors 'fg+:#665c54,bg+:#f2e5bc'`.
+
+[Fzf-color-picker](https://minsw.github.io/fzf-color-picker/) can help you pick color overrides you want.
+
 ### Pass fzf options for a specific command
 
 The following variables can store custom options that will be passed to fzf by their respective command:

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -14,6 +14,9 @@ function _fzf_wrapper --description "Prepares some environment variables before 
         # preview-window=wrap wraps long lines in the preview window, making reading easier
         # marker=* makes the multi-select marker more distinguishable from the pointer (since both default to >)
         set --export FZF_DEFAULT_OPTS '--cycle --layout=reverse --border --height=90% --preview-window=wrap --marker="*"'
+        if set --query fzf_fish_colors
+            set --export FZF_DEFAULT_OPTS $FZF_DEFAULT_OPTS" --color=$fzf_fish_colors"
+        end
     end
 
     fzf $argv


### PR DESCRIPTION
fzf.nvim already relies on highlighting done by fd and bat, but not all colors are set by them. This setting allows people to configure FZF colors not affected by fd or bat while keeping default options fzf.nvim provides.