### PR TITLE
Added GPG output check

### DIFF
--- a/functions/_fzf_search_git_log.fish
+++ b/functions/_fzf_search_git_log.fish
@@ -4,9 +4,9 @@ function _fzf_search_git_log --description "Search the output of git log and pre
     else
         # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
         # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
-        set log_fmt_str '%C(bold blue)%h%C(reset) - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
+        set log_fmt_str '%C(bold blue)%h%C(reset) - [%G?] - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
         set selected_log_lines (
-            git log --color=always --format=format:$log_fmt_str --date=short | \
+            git log --no-show-signature --color=always --format=format:$log_fmt_str --date=short | \
             _fzf_wrapper --ansi \
                 --multi \
                 --tiebreak=index \

--- a/functions/_fzf_search_git_log.fish
+++ b/functions/_fzf_search_git_log.fish
@@ -4,7 +4,7 @@ function _fzf_search_git_log --description "Search the output of git log and pre
     else
         # see documentation for git format placeholders at https://git-scm.com/docs/git-log#Documentation/git-log.txt-emnem
         # %h gives you the abbreviated commit hash, which is useful for saving screen space, but we will have to expand it later below
-        set log_fmt_str '%C(bold blue)%h%C(reset) - [%G?] - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
+        set log_fmt_str '%C(bold blue)%h%C(reset) - %C(cyan)%ad%C(reset) %C(yellow)%d%C(reset) %C(normal)%s%C(reset)  %C(dim normal)[%an]%C(reset)'
         set selected_log_lines (
             git log --no-show-signature --color=always --format=format:$log_fmt_str --date=short | \
             _fzf_wrapper --ansi \


### PR DESCRIPTION
Fixed the raw GPG output that leaked in the commit list for repos that have the `showSignature = true` git configuration. The values of the check are specified in the [`%G?` format specifier](https://git-scm.com/docs/git-log#Documentation/git-log.txt-emGem) for `git log`

Resolves #286 