### PR TITLE
[Search Git Status] use box drawing chars for staged/unstaged header

### DIFF
--- a/functions/_fzf_report_diff_type.fish
+++ b/functions/_fzf_report_diff_type.fish
@@ -1,16 +1,18 @@
 # helper for _fzf_preview_changed_file
 # prints out something like
-# +--------+
-# | Staged |
-# +--------+
+# ╭────────╮
+# │ Staged │
+# ╰────────╯
 function _fzf_report_diff_type --argument-names diff_type --description "Print a distinct colored header meant to preface a git patch."
     # number of "-" to draw is the length of the string to box + 2 for padding
     set repeat_count (math 2 + (string length $diff_type))
-    set horizontal_border +(string repeat --count $repeat_count -)+
+    set line (string repeat --count $repeat_count ─)
+    set top_border ╭$line╮
+    set btm_border ╰$line╯
 
     set_color yellow
-    echo $horizontal_border
-    echo "| $diff_type |"
-    echo $horizontal_border
+    echo $top_border
+    echo "│ $diff_type │"
+    echo $btm_border
     set_color normal
 end

--- a/tests/preview_changed_file/deleted_in_working.fish
+++ b/tests/preview_changed_file/deleted_in_working.fish
@@ -1,5 +1,5 @@
 mock git diff "echo \$argv"
 set output (_fzf_preview_changed_file " D out.log")
 
-contains "| Unstaged |" $output && not contains "| Staged |" $output
+contains "│ Unstaged │" $output && not contains "│ Staged │" $output
 @test "only shows unstaged changes if file was only deleted in working tree" $status -eq 0

--- a/tests/preview_changed_file/merge_conflict.fish
+++ b/tests/preview_changed_file/merge_conflict.fish
@@ -1,4 +1,4 @@
 mock git diff "echo \$argv"
 set output (_fzf_preview_changed_file "UU out.log")
 
-@test "shows merge conflicts as unmerged" $output[2] = "| Unmerged |"
+@test "shows merge conflicts as unmerged" $output[2] = "│ Unmerged │"

--- a/tests/preview_changed_file/modified_in_both.fish
+++ b/tests/preview_changed_file/modified_in_both.fish
@@ -1,5 +1,5 @@
 mock git diff "echo \$argv"
 set output (_fzf_preview_changed_file "MM dir/file.txt")
 
-contains "| Unstaged |" $output && contains "| Staged |" $output
+contains "│ Unstaged │" $output && contains "│ Staged │" $output
 @test "shows staged and unstaged changes if the file is modified in both places" $status -eq 0


### PR DESCRIPTION
This makes the little header box for Git staged/unstaged/merged/etc. look a bit nicer.

Old:
```
+--------+
| Staged |
+--------+
```

New:
```
╭────────╮
│ Staged │
╰────────╯
```

It does not look perfect on GitHub web, but works in a terminal with a proper font:
![image](https://user-images.githubusercontent.com/122564/214265661-816daede-f373-44c6-ac6a-d8e77b81b448.png)


We could make this optional (add some `$_fzf_fish_use_unicode_box` variable), but `fzf` itself is
also using those box drawing characters by default, so I guess pretty much everyone using `fzf.fish`
should be fine with it.