### PR TITLE
[feat] Added "Search Units" function for searching systemd units

### DIFF
--- a/functions/_fzf_configure_bindings_help.fish
+++ b/functions/_fzf_configure_bindings_help.fish
@@ -17,6 +17,7 @@ DESCRIPTION
         Search History     |  Ctrl+R     (R for reverse)   |  --history
         Search Processes   |  Ctrl+Alt+P (P for process)   |  --processes
         Search Variables   |  Ctrl+V     (V for variable)  |  --variables
+        Search Units       |  Ctrl+Alt+U (U for units)     |  --units
     Override a command's binding by specifying its corresponding option with the desired key
     sequence. Disable a command's binding by specifying its corresponding option with no value.
 

--- a/functions/_fzf_search_units.fish
+++ b/functions/_fzf_search_units.fish
@@ -1,0 +1,33 @@
+function _fzf_search_units --description "Search all systemd services. Replace the current token with the service name of the selected services"
+    if ! command --query systemctl
+        echo "Not a systemd machine, can't query systemd units"
+        exit 1
+    end
+
+    set systemctl_cmd systemctl list-units --all --no-pager --plain --type service $fzf_systemctl_opts
+
+    set units_selected (
+        $systemctl_cmd --no-legend | \
+        _fzf_wrapper --multi \
+                    --prompt="Search Units> " \
+                    --query (commandline --current-token) \
+		    # systemctl --no-legend provides no header; but with a legend provides
+		    # useless statistics at the bottom, with arbitary amounts of lines.
+		    # Get the headers by searching again, and only grabbing the header line
+                    --header ($systemctl_cmd | head -n1 | string trim -l) \
+                    --preview="SYSTEMD_COLORS=1 systemctl status -- {1}" \
+                    --preview-window="bottom:15:wrap" \
+                    $fzf_units_opts
+    )
+
+    if test $status -eq 0
+        for unit in $units_selected
+            set --append services_selected (string split --no-empty --field=1 -- " " $unit)
+        end
+
+        # string join to replace the newlines outputted by string split with spaces
+        commandline --current-token --replace -- (string join ' ' $services_selected)
+    end
+
+    commandline --function repaint
+end

--- a/functions/fzf_configure_bindings.fish
+++ b/functions/fzf_configure_bindings.fish
@@ -4,7 +4,7 @@ function fzf_configure_bindings --description "Installs the default key bindings
     # no need to install bindings if not in interactive mode or running tests
     status is-interactive || test "$CI" = true; or return
 
-    set options_spec h/help 'directory=?' 'git_log=?' 'git_status=?' 'history=?' 'processes=?' 'variables=?'
+    set options_spec h/help 'directory=?' 'git_log=?' 'git_status=?' 'history=?' 'processes=?' 'variables=?' 'units=?'
     argparse --max-args=0 --ignore-unknown $options_spec -- $argv 2>/dev/null
     if test $status -ne 0
         echo "Invalid option or a positional argument was provided." >&2
@@ -16,13 +16,15 @@ function fzf_configure_bindings --description "Installs the default key bindings
     else
         # Initialize with default key sequences and then override or disable them based on flags
         # index 1 = directory, 2 = git_log, 3 = git_status, 4 = history, 5 = processes, 6 = variables
-        set key_sequences \e\cf \e\cl \e\cs \cr \e\cp \cv # \c = control, \e = escape
+        # index 7 = units
+        set key_sequences \e\cf \e\cl \e\cs \cr \e\cp \cv \e\cu # \c = control, \e = escape
         set --query _flag_directory && set key_sequences[1] "$_flag_directory"
         set --query _flag_git_log && set key_sequences[2] "$_flag_git_log"
         set --query _flag_git_status && set key_sequences[3] "$_flag_git_status"
         set --query _flag_history && set key_sequences[4] "$_flag_history"
         set --query _flag_processes && set key_sequences[5] "$_flag_processes"
         set --query _flag_variables && set key_sequences[6] "$_flag_variables"
+        set --query _flag_units && set key_sequences[7] "$_flag_units"
 
         # If fzf bindings already exists, uninstall it first for a clean slate
         if functions --query _fzf_uninstall_bindings
@@ -36,6 +38,7 @@ function fzf_configure_bindings --description "Installs the default key bindings
             test -n $key_sequences[4] && bind --mode $mode $key_sequences[4] _fzf_search_history
             test -n $key_sequences[5] && bind --mode $mode $key_sequences[5] _fzf_search_processes
             test -n $key_sequences[6] && bind --mode $mode $key_sequences[6] "$_fzf_search_vars_command"
+            test -n $key_sequences[7] && bind --mode $mode $key_sequences[7] _fzf_search_units
         end
 
         function _fzf_uninstall_bindings --inherit-variable key_sequences


### PR DESCRIPTION
I've added a command (CTRL+ALT+U - - U for systemd [U]nits)

I'm not too sure it fits the criteria of being widely useful, but as an admin, being able to search&select large swaps of services is super handy. I wanted to share in any case :-)

It's very simple, and is based on the Search Processes function; searching through `systemctl list-units` with common options (searching only services by default), and extensible via the `fzf_systemctl_opts`-variable  (i.e. if you want more than just services), returning only the selected unit names.

The preview window shows the status (with colors) of the selected unit, and if access is given (being apart of the `systemd-journal` or `adm` groups), it will show you the logs for that unit (systemctl has a default of 10 lines)

I have tested this with systemctl versions `237` (the current one on Ubuntu 18.04), `245` (current on Ubuntu 20.04), and `249` (current on Ubuntu 22.04)

I don't know if there is a fish equivalent to `head` which I've used. But that would be a nice improvement :-)

![image](https://user-images.githubusercontent.com/7879747/215710592-be3c13fa-7909-4705-a209-ab98d8710218.png)
