### PR TITLE
[Search history] Make date time format configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ set fzf_git_log_format "%H %s"
 
 The format must be one line per commit and the hash must be the first field, or else Search Git Log will fail to determine which commits you selected.
 
+### Change the time format used by Search History
+
+Search History prints the time each command was executed. To use your own [time format](https://devhints.io/strftime), set it in `fzf_history_time_format`. For example, this shows on what day of the week the command was executed:
+
+```fish
+set fzf_history_time_format "%A"
+```
+
+Note that the time format cannot include the unicode character `│` (not to be confused with the very similar `|`, the pipe symbol, which is allowed).
+
 ## Further reading
 
 Find answers to these questions and more in the [project Wiki](https://github.com/PatrickF1/fzf.fish/wiki):

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ The format must be one line per commit and the hash must be the first field, or 
 
 ### Change the date time format used by Search History
 
-Search History prepends each command shown with the date and time it was executed. To change how the date and time are formatted, set your [strftime format string](https://devhints.io/strftime) in `fzf_history_time_format`.
-Note that the time format cannot include the unicode character `│` (not to be confused with the very similar `|`, the pipe symbol, which is allowed).
+[Search History][] shows the date and time each command was executed. To change how the date and time are formatted, set your [strftime format string](https://devhints.io/strftime) in `fzf_history_time_format`.
+Do not to use the vertical box-drawing character `│`, as it is used to delineate the date and time from the command.
 
 ## Further reading
 

--- a/README.md
+++ b/README.md
@@ -179,14 +179,9 @@ set fzf_git_log_format "%H %s"
 
 The format must be one line per commit and the hash must be the first field, or else Search Git Log will fail to determine which commits you selected.
 
-### Change the time format used by Search History
+### Change the date time format used by Search History
 
-Search History prints the time each command was executed. To use your own [time format](https://devhints.io/strftime), set it in `fzf_history_time_format`. For example, this shows on what day of the week the command was executed:
-
-```fish
-set fzf_history_time_format "%A"
-```
-
+Search History prepends each command shown with the date and time it was executed. To change how the date and time are formatted, set your [strftime format string](https://devhints.io/strftime) in `fzf_history_time_format`.
 Note that the time format cannot include the unicode character `│` (not to be confused with the very similar `|`, the pipe symbol, which is allowed).
 
 ## Further reading

--- a/README.md
+++ b/README.md
@@ -181,7 +181,12 @@ The format must be one line per commit and the hash must be the first field, or 
 
 ### Change the date time format used by Search History
 
-[Search History][] shows the date time each command was executed. To change how its formatted, set your [strftime format string](https://devhints.io/strftime) in `fzf_history_time_format`.
+[Search History][] shows the date time each command was executed. To change how its formatted, set your [strftime format string](https://devhints.io/strftime) in `fzf_history_time_format`. For example, this shows the date time as DD-MM-YY:
+
+```fish
+set fzf_history_time_format %d-%m-%y
+```
+
 Do not to include the vertical box-drawing character `│` (not to be confused with the pipe character `|`) as it is relied on to delineate the date time from the command.
 
 ## Further reading

--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ The format must be one line per commit and the hash must be the first field, or 
 
 ### Change the date time format used by Search History
 
-[Search History][] shows the date and time each command was executed. To change how the date and time are formatted, set your [strftime format string](https://devhints.io/strftime) in `fzf_history_time_format`.
-Do not to use the vertical box-drawing character `│`, as it is used to delineate the date and time from the command.
+[Search History][] shows the date time each command was executed. To change how its formatted, set your [strftime format string](https://devhints.io/strftime) in `fzf_history_time_format`.
+Do not to include the vertical box-drawing character `│` (not to be confused with the pipe character `|`) as it is relied on to delineate the date time from the command.
 
 ## Further reading
 

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -5,22 +5,26 @@ function _fzf_search_history --description "Search command history. Replace the 
         builtin history merge
     end
 
+    if not set --query fzf_history_time_format
+        # Reference https://devhints.io/strftime to understand strftime format symbols
+        set -f fzf_history_time_format "%m-%d %H:%M:%S"
+    end
+
     # Delinate commands throughout pipeline using null rather than newlines because commands can be multi-line
     set -f commands_selected (
-        # Reference https://devhints.io/strftime to understand strftime format symbols
-        builtin history --null --show-time="%m-%d %H:%M:%S │ " |
+        builtin history --null --show-time="$fzf_history_time_format │ " |
         _fzf_wrapper --read0 \
             --print0 \
             --multi \
             --tiebreak=index \
             --prompt="Search History> " \
             --query=(commandline) \
-            --preview="echo -- {4..} | fish_indent --ansi" \
+            --preview="echo -- {} | string replace --regex '^.*? │ ' '' | fish_indent --ansi" \
             --preview-window="bottom:3:wrap" \
             $fzf_history_opts |
         string split0 |
         # remove timestamps from commands selected
-        string replace --regex '^\d\d-\d\d \d\d:\d\d:\d\d │ ' ''
+        string replace --regex '^.*? │ ' ''
     )
 
     if test $status -eq 0


### PR DESCRIPTION
Enable configuring the format of command execution times in Search History through the new `fzf_history_time_format` variable. This is highly valuable for non-US users who may be accustomed to reading dates as day-month (rather than month-day as the default is), or for people who want to search through previous years of command history.