### PR TITLE
[Search History][Search Git Log] use history scoring scheme

### DIFF
--- a/functions/_fzf_search_git_log.fish
+++ b/functions/_fzf_search_git_log.fish
@@ -10,7 +10,7 @@ function _fzf_search_git_log --description "Search the output of git log and pre
             git log --no-show-signature --color=always --format=format:$fzf_git_log_format --date=short | \
             _fzf_wrapper --ansi \
                 --multi \
-                --tiebreak=index \
+                --scheme=history \
                 --prompt="Search Git Log> " \
                 --preview='git show --color=always --stat --patch {1}' \
                 --query=(commandline --current-token) \

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -16,7 +16,7 @@ function _fzf_search_history --description "Search command history. Replace the 
         _fzf_wrapper --read0 \
             --print0 \
             --multi \
-            --tiebreak=index \
+            --scheme=history \
             --prompt="Search History> " \
             --query=(commandline) \
             --preview="echo -- {} | string replace --regex '^.*? │ ' '' | fish_indent --ansi" \


### PR DESCRIPTION
This improves ranking by using age not only as tiebreaker, but giving it more weight. I for example have some commands which I use almost daily but which always appear third or even lower in the list, due to some other commands (which I didn't use for months) matching *a little bit* better.

From the man page:

 ```
      --scheme=SCHEME
              Choose scoring scheme tailored for different types of input.

              default  Generic scoring scheme designed to work well with any type of input
              path     Scoring scheme for paths (additional bonus point only after path separator)
              history  Scoring scheme for command history (no additional bonus points).
                       Sets --tiebreak=index as well.
```