### PR TITLE
replace exa with eza in example now that exa is unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Find more ideas and implementation tips in the [Cookbook](https://github.com/Pat
 To use your own directory preview command, set it in `fzf_preview_dir_cmd`:
 
 ```fish
-set fzf_preview_dir_cmd exa --all --color=always
+set fzf_preview_dir_cmd eza --all --color=always
 ```
 
 And to use your own file preview command, set it in `fzf_preview_file_cmd`:


### PR DESCRIPTION
[exa](https://github.com/ogham/exa/issues/1243) is now unmaintained. `eza` is a fork that is essentially a drop in replacement for `exa`. This PR encourages its use over the former. 😄 