### PR TITLE
Remove unnecessary "Search" from prompts

### DIFF
--- a/functions/_fzf_search_directory.fish
+++ b/functions/_fzf_search_directory.fish
@@ -17,10 +17,10 @@ function _fzf_search_directory --description "Search the current directory. Repl
     if string match --quiet -- "*/" $unescaped_exp_token && test -d "$unescaped_exp_token"
         set --append fd_cmd --base-directory=$unescaped_exp_token
         # use the directory name as fzf's prompt to indicate the search is limited to that directory
-        set --prepend fzf_arguments --prompt="Search Directory $unescaped_exp_token> " --preview="_fzf_preview_file $expanded_token{}"
+        set --prepend fzf_arguments --prompt="Directory $unescaped_exp_token> " --preview="_fzf_preview_file $expanded_token{}"
         set -f file_paths_selected $unescaped_exp_token($fd_cmd 2>/dev/null | _fzf_wrapper $fzf_arguments)
     else
-        set --prepend fzf_arguments --prompt="Search Directory> " --query="$unescaped_exp_token" --preview='_fzf_preview_file {}'
+        set --prepend fzf_arguments --prompt="Directory> " --query="$unescaped_exp_token" --preview='_fzf_preview_file {}'
         set -f file_paths_selected ($fd_cmd 2>/dev/null | _fzf_wrapper $fzf_arguments)
     end
 

--- a/functions/_fzf_search_git_log.fish
+++ b/functions/_fzf_search_git_log.fish
@@ -17,7 +17,7 @@ function _fzf_search_git_log --description "Search the output of git log and pre
             _fzf_wrapper --ansi \
                 --multi \
                 --scheme=history \
-                --prompt="Search Git Log> " \
+                --prompt="Git Log> " \
                 --preview=$preview_cmd \
                 --query=(commandline --current-token) \
                 $fzf_git_log_opts

--- a/functions/_fzf_search_git_status.fish
+++ b/functions/_fzf_search_git_status.fish
@@ -12,7 +12,7 @@ function _fzf_search_git_status --description "Search the output of git status. 
             git -c color.status=always status --short |
             _fzf_wrapper --ansi \
                 --multi \
-                --prompt="Search Git Status> " \
+                --prompt="Git Status> " \
                 --query=(commandline --current-token) \
                 --preview=$preview_cmd \
                 --nth="2.." \

--- a/functions/_fzf_search_history.fish
+++ b/functions/_fzf_search_history.fish
@@ -21,7 +21,7 @@ function _fzf_search_history --description "Search command history. Replace the 
             --print0 \
             --multi \
             --scheme=history \
-            --prompt="Search History> " \
+            --prompt="History> " \
             --query=(commandline) \
             --preview="string replace --regex '$time_prefix_regex' '' -- {} | fish_indent --ansi" \
             --preview-window="bottom:3:wrap" \

--- a/functions/_fzf_search_processes.fish
+++ b/functions/_fzf_search_processes.fish
@@ -8,7 +8,7 @@ function _fzf_search_processes --description "Search all running processes. Repl
     set -f processes_selected (
         $ps_cmd -A -opid,command | \
         _fzf_wrapper --multi \
-                    --prompt="Search Processes> " \
+                    --prompt="Processes> " \
                     --query (commandline --current-token) \
                     --ansi \
                     # first line outputted by ps is a header, so we need to mark it as so

--- a/functions/_fzf_search_variables.fish
+++ b/functions/_fzf_search_variables.fish
@@ -23,7 +23,7 @@ function _fzf_search_variables --argument-names set_show_output set_names_output
     set -f variable_names_selected (
         printf '%s\n' $all_variable_names |
         _fzf_wrapper --preview "_fzf_extract_var_info {} $set_show_output" \
-            --prompt="Search Variables> " \
+            --prompt="Variables> " \
             --preview-window="wrap" \
             --multi \
             --query=$cleaned_curr_token \


### PR DESCRIPTION
There is no need to specify "Search" in input prompts since that's all fzf does.

Reducing prompt length helps with reading, especially in limited spaces (e.g. terminal splits).