### PR TITLE
Add support for FZF_DEFAULT_OPTS_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Call `fzf_configure_bindings` in your `config.fish` in order to persist your cus
 
 ### Change fzf options for all commands
 
-fzf supports global default options via the [FZF_DEFAULT_OPTS](https://github.com/junegunn/fzf#environment-variables) environment variable.
+fzf supports global default options via the [FZF_DEFAULT_OPTS or FZF_DEFAULT_OPTS_FILE](https://github.com/junegunn/fzf#environment-variables) environment variables.
 
-`fzf.fish` sets [a sane `FZF_DEFAULT_OPTS` whenever it executes fzf](functions/_fzf_wrapper.fish). If you export your own `FZF_DEFAULT_OPTS`, then yours will be used instead.
+`fzf.fish` sets [a sane `FZF_DEFAULT_OPTS` whenever it executes fzf](functions/_fzf_wrapper.fish) unless you export your own `FZF_DEFAULT_OPTS` or `FZF_DEFAULT_OPTS_FILE`.
 
 ### Change fzf options for a specific command
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,7 @@ Call `fzf_configure_bindings` in your `config.fish` in order to persist your cus
 
 ### Change fzf options for all commands
 
-fzf supports global default options via the [FZF_DEFAULT_OPTS or FZF_DEFAULT_OPTS_FILE](https://github.com/junegunn/fzf#environment-variables) environment variables.
-
-`fzf.fish` sets [a sane `FZF_DEFAULT_OPTS` whenever it executes fzf](functions/_fzf_wrapper.fish) unless you export your own `FZF_DEFAULT_OPTS` or `FZF_DEFAULT_OPTS_FILE`.
+fzf supports global default options via the [FZF_DEFAULT_OPTS and FZF_DEFAULT_OPTS_FILE](https://github.com/junegunn/fzf#environment-variables) environment variables. If neither are set, `fzf.fish` sets its own [default opts whenever it executes fzf](functions/_fzf_wrapper.fish).
 
 ### Change fzf options for a specific command
 

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -4,9 +4,9 @@ function _fzf_wrapper --description "Prepares some environment variables before 
     # Use --function so that it doesn't clobber SHELL outside this function.
     set -f --export SHELL (command --search fish)
 
-    # If FZF_DEFAULT_OPTS is not set, then set some sane defaults.
+    # If FZF_DEFAULT_OPTS or FZF_DEFAULT_OPTS_FILE is not set, then set some sane defaults.
     # See https://github.com/junegunn/fzf#environment-variables
-    if not set --query FZF_DEFAULT_OPTS
+    if not set --query FZF_DEFAULT_OPTS || not set --query FZF_DEFAULT_OPTS_FILE
         # cycle allows jumping between the first and last results, making scrolling faster
         # layout=reverse lists results top to bottom, mimicking the familiar layouts of git log, history, and env
         # border shows where the fzf window begins and ends

--- a/functions/_fzf_wrapper.fish
+++ b/functions/_fzf_wrapper.fish
@@ -4,9 +4,10 @@ function _fzf_wrapper --description "Prepares some environment variables before 
     # Use --function so that it doesn't clobber SHELL outside this function.
     set -f --export SHELL (command --search fish)
 
-    # If FZF_DEFAULT_OPTS or FZF_DEFAULT_OPTS_FILE is not set, then set some sane defaults.
+    # If neither FZF_DEFAULT_OPTS nor FZF_DEFAULT_OPTS_FILE are set, then set some sane defaults.
     # See https://github.com/junegunn/fzf#environment-variables
-    if not set --query FZF_DEFAULT_OPTS || not set --query FZF_DEFAULT_OPTS_FILE
+    set --query FZF_DEFAULT_OPTS FZF_DEFAULT_OPTS_FILE
+    if test $status -eq 2
         # cycle allows jumping between the first and last results, making scrolling faster
         # layout=reverse lists results top to bottom, mimicking the familiar layouts of git log, history, and env
         # border shows where the fzf window begins and ends


### PR DESCRIPTION
Don't set default fzf options if FZF_DEFAULT_OPTS_FILE is set. FZF_DEFAULT_OPTS_FILE was added to fzf in version [0.47.0](https://github.com/junegunn/fzf/releases/tag/0.47.0)